### PR TITLE
✨ feat: use keyword shortcut without argument

### DIFF
--- a/Community.PowerToys.Run.Plugin.WebSearchShortcut/Main.cs
+++ b/Community.PowerToys.Run.Plugin.WebSearchShortcut/Main.cs
@@ -145,7 +145,7 @@ namespace Community.PowerToys.Run.Plugin.WebSearchShortcut
 
       if (string.IsNullOrEmpty(args))
       {
-        results.AddRange(WebSearchShortcutStorage.GetRecords().Select(x => GetResultForSelect(x, args, query)));
+        results.AddRange(WebSearchShortcutStorage.GetRecords().Select(x => GetResultForSelectOrOpen(x, args, query)));
         return results;
       }
 
@@ -153,7 +153,7 @@ namespace Community.PowerToys.Run.Plugin.WebSearchShortcut
 
       if (tokens.Length == 1)
       {
-        results.AddRange(WebSearchShortcutStorage.GetRecords(args).Select(x => GetResultForSelect(x, args, query)));
+        results.AddRange(WebSearchShortcutStorage.GetRecords(args).Select(x => GetResultForSelectOrOpen(x, args, query)));
       }
 
       var item = WebSearchShortcutStorage.GetRecord(tokens[0]);
@@ -249,7 +249,7 @@ namespace Community.PowerToys.Run.Plugin.WebSearchShortcut
         SuggestionsCache = [.. results];
         if (tokens.Length == 1)
         {
-          results.AddRange(WebSearchShortcutStorage.GetRecords(tokens[0]).Select(x => GetResultForSelect(x, tokens[0], query)));
+          results.AddRange(WebSearchShortcutStorage.GetRecords(tokens[0]).Select(x => GetResultForSelectOrOpen(x, tokens[0], query)));
         }
         results.Add(GetResultForSearch(defaultItem, query.Search, query, true));
 
@@ -259,8 +259,26 @@ namespace Community.PowerToys.Run.Plugin.WebSearchShortcut
 
     private List<Result> SuggestionsCache { get; set; } = [];
 
-    private Result GetResultForSelect(Item item, string args, Query query)
+    private Result GetResultForSelectOrOpen(Item item, string args, Query query)
     {
+      string url = item.Url;
+
+      if (!url.Contains("%s"))
+      {
+        return new Result
+        {
+          ProgramArguments = url,
+          QueryTextDisplay = args,
+          IcoPath = item.IconPath ?? IconPath["Search"],
+          Title = item.Name,
+          SubTitle = $"Open {item.Name} with {BrowserInfo.Name}",
+          Score = 100,
+          Action = _ => OpenInBrowser(url),
+          ToolTipData = new ToolTipData("Open (Enter)", $"{url}"),
+          ContextData = item,
+        };
+      }
+
       return new Result
       {
         QueryTextDisplay = args,

--- a/Community.PowerToys.Run.Plugin.WebSearchShortcut/Storage.cs
+++ b/Community.PowerToys.Run.Plugin.WebSearchShortcut/Storage.cs
@@ -100,6 +100,7 @@ namespace Community.PowerToys.Run.Plugin.WebSearchShortcut
       .FirstOrDefault(x =>
         (x.Name?.Equals(key, StringComparison.InvariantCultureIgnoreCase) ?? false)
         || (x.Keyword?.Equals(key, StringComparison.InvariantCultureIgnoreCase) ?? false)
+        || x.Url.Equals("%s")
         );
     }
 

--- a/Community.PowerToys.Run.Plugin.WebSearchShortcut/Storage.cs
+++ b/Community.PowerToys.Run.Plugin.WebSearchShortcut/Storage.cs
@@ -98,10 +98,9 @@ namespace Community.PowerToys.Run.Plugin.WebSearchShortcut
       return Data.Values
       // .Where(x => x.IsDefault != true)
       .FirstOrDefault(x =>
-        (x.Name?.Equals(key, StringComparison.InvariantCultureIgnoreCase) ?? false)
+        ((x.Name?.Equals(key, StringComparison.InvariantCultureIgnoreCase) ?? false)
         || (x.Keyword?.Equals(key, StringComparison.InvariantCultureIgnoreCase) ?? false)
-        || x.Url.Equals("%s")
-        );
+        ) && x.Url.Contains("%s"));
     }
 
     public Item? DefaultItem => Data.Values.FirstOrDefault(x => x?.IsDefault == true, null);


### PR DESCRIPTION
#9 
现在可以直接打开 ”不带参数的url“
注意：当你的关键字同时命中多个不同的配置时，插件并不会提高 ”不带参数的url“ 的优先级，候选列表将按照之前的排序规则运作