### PR TITLE
 Implement "ReplaceWhitespace" config option

### DIFF
--- a/Community.PowerToys.Run.Plugin.WebSearchShortcut/Main.cs
+++ b/Community.PowerToys.Run.Plugin.WebSearchShortcut/Main.cs
@@ -326,7 +326,7 @@ namespace Community.PowerToys.Run.Plugin.WebSearchShortcut
 
     private static Result GetResultForSearch(Item item, string search, Query query, bool isDefault = false)
     {
-      string searchQuery = WebUtility.UrlEncode(search);
+      string searchQuery = item.EncodeUrl(search);
       string arguments = item.Url.Replace("%s", searchQuery);
       return new Result
       {
@@ -351,7 +351,7 @@ namespace Community.PowerToys.Run.Plugin.WebSearchShortcut
         IcoPath = IconPath["Suggestion"],
         Title = suggest.Title,
         SubTitle = suggest.Description,
-        Action = _ => OpenInBrowser(item.Url.Replace("%s", WebUtility.UrlEncode(suggest.Title))),
+        Action = _ => OpenInBrowser(item.Url.Replace("%s", item.EncodeUrl(search))),
         ContextData = item,
         Score = 99,
       };

--- a/Community.PowerToys.Run.Plugin.WebSearchShortcut/Models/Item.cs
+++ b/Community.PowerToys.Run.Plugin.WebSearchShortcut/Models/Item.cs
@@ -1,5 +1,6 @@
 using System;
 using System.IO;
+using System.Net;
 using System.Net.Http;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
@@ -54,6 +55,13 @@ namespace Community.PowerToys.Run.Plugin.WebSearchShortcut.Models
     }
 
     public string? IconPath { get; set; }
+
+    public string? ReplaceWhitespace { get; set; }
+
+    public string EncodeUrl(string url) {
+      if (string.IsNullOrEmpty(ReplaceWhitespace) || ReplaceWhitespace == " ") return WebUtility.UrlEncode(url);
+      return WebUtility.UrlEncode(url.Replace(" ", ReplaceWhitespace));
+    }
 
     public async Task<bool> DownLoadIcon()
     {

--- a/Community.PowerToys.Run.Plugin.WebSearchShortcut/Models/Item.cs
+++ b/Community.PowerToys.Run.Plugin.WebSearchShortcut/Models/Item.cs
@@ -59,7 +59,10 @@ namespace Community.PowerToys.Run.Plugin.WebSearchShortcut.Models
     public string? ReplaceWhitespace { get; set; }
 
     public string EncodeUrl(string url) {
-      if (string.IsNullOrEmpty(ReplaceWhitespace) || ReplaceWhitespace == " ") return WebUtility.UrlEncode(url);
+      if (string.IsNullOrWhiteSpace(ReplaceWhitespace) || ReplaceWhitespace == " ")
+      {
+        return WebUtility.UrlEncode(url);
+      }
       return WebUtility.UrlEncode(url.Replace(" ", ReplaceWhitespace));
     }
 

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Used to quickly select the target search engine.
 Used to set the search suggestion.
 
 **SuggestionProvider currently supported are:**
+
 - `Google`
 - `Bing`
 - `Npm`
@@ -37,6 +38,7 @@ PR welcome!
 
 > You can also set a Provider to another search engine.
 > eg:
+>
 > ```json
 > {
 >   "StackOverflow": {
@@ -54,6 +56,14 @@ If this option is true, the corresponding search engine does not need to input t
 
 You can customize the icon by setting this field. Under normal circumstances, you don't need to set this, as the plugin will automatically download the favicon of the website corresponding to the `Url` field. However, sometimes you might want to customize the icon, and this field comes in handy. **Note**: This field can only be set to a network URL and cannot be set to a local file.
 
+### `ReplaceWhitespace`
+
+You can specify which character(s) to replace a space with when performing a search.
+
+For example, Wikipedia uses underscores (`_`), not plus signs (`+`) to separate words in the URL. "This is a test" → `https://en.wikipedia.org/wiki/This+is+a+test` (invalid ❌).
+
+By setting `ReplaceWhitespace = "_"` for a search engine, the plugin will replace all spaces with underscores when performing the search. "This is a test" → `https://en.wikipedia.org/wiki/This_is_a_test` (valid ✅).
+
 ## Installation
 
 - Download the [latest release](https://github.com/Daydreamer-riri/PowerToys-Run-WebSearchShortcut/releases/) by selecting the architecture that matches your machine: `x64` (more common) or `ARM64`
@@ -69,6 +79,7 @@ You can customize the icon by setting this field. Under normal circumstances, yo
 
 - Inside the config file, you can add your desired search engines. The key is the display name of the search engine, and the `url` property is the URL template for performing the search.
 eg:
+
 ```json
 {
   "Google": {


### PR DESCRIPTION
Allows the user to specify a replacement character for any whitespace present in the search string.

This allows better configuration for sites that don't separate spaces with "+" (the default), such as Wikipedia (which uses an underscore "_").

By default, this change will set the inner default value of the new `ReplaceWhitespace` property to a space " ". This ensures backwards compatibility with any current setup or search patterns any user has.