### PR TITLE
feat: support custom HomePage URL

### DIFF
--- a/CmdPalWebSearchShortcut/WebSearchShortcut/Commands/OpenHomePageCommand.cs
+++ b/CmdPalWebSearchShortcut/WebSearchShortcut/Commands/OpenHomePageCommand.cs
@@ -1,17 +1,19 @@
 
 using Microsoft.CommandPalette.Extensions.Toolkit;
 
+using WebSearchShortcut.Helpers;
+
 using BrowserInfo = WebSearchShortcut.Helpers.DefaultBrowserInfo;
 
 namespace WebSearchShortcut.Commands;
 
-internal sealed partial class OpenDomainCommand : InvokableCommand
+internal sealed partial class OpenHomePageCommand : InvokableCommand
 {
   // private readonly SettingsManager _settingsManager;
 
   public WebSearchShortcutItem Item;
 
-  internal OpenDomainCommand(WebSearchShortcutItem item)
+  internal OpenHomePageCommand(WebSearchShortcutItem item)
   {
     BrowserInfo.UpdateIfTimePassed();
     Icon = new IconInfo("\uE721");
@@ -24,7 +26,7 @@ internal sealed partial class OpenDomainCommand : InvokableCommand
 
   public override CommandResult Invoke()
   {
-    if (!ShellHelpers.OpenCommandInShell(BrowserInfo.Path, BrowserInfo.ArgumentsPattern, $"{Item.Domain}"))
+    if (!HomePageLauncher.OpenHomePageWithBrowser(Item))
     {
       // TODO GH# 138 --> actually display feedback from the extension somewhere.
       return CommandResult.KeepOpen();

--- a/CmdPalWebSearchShortcut/WebSearchShortcut/Forms/AddShortcutForm.cs
+++ b/CmdPalWebSearchShortcut/WebSearchShortcut/Forms/AddShortcutForm.cs
@@ -19,6 +19,7 @@ internal sealed partial class AddShortcutForm : FormContent
         var url = _item?.Url ?? string.Empty;
         var suggestionProvider = _item?.SuggestionProvider ?? string.Empty;
         var replaceWhitespace = _item?.ReplaceWhitespace ?? string.Empty;
+        var homePage = _item?.HomePage ?? string.Empty;
 
         TemplateJson = $$"""
 {
@@ -72,6 +73,16 @@ internal sealed partial class AddShortcutForm : FormContent
             "label": "ReplaceWhitespace",
             "placeholder": "Specify which character(s) to replace a space",
             "errorMessage": "//"
+        },
+        {
+            "type": "Input.Text",
+            "style": "text",
+            "id": "homePage",
+            "value": {{JsonSerializer.Serialize(homePage, AppJsonSerializerContext.Default.String)}},
+            "label": "HomePage",
+            "placeholder": "Specify the URL to open as the home page",
+            "isRequired": false,
+            "errorMessage": "//"
         }
     ],
     "actions": [
@@ -82,7 +93,8 @@ internal sealed partial class AddShortcutForm : FormContent
                 "name": "name",
                 "url": "url",
                 "suggestionProvider": "suggestionProvider",
-                "replaceWhitespace": "replaceWhitespace"
+                "replaceWhitespace": "replaceWhitespace",
+                "homePage": "homePage"
             }
         }
     ]
@@ -103,12 +115,14 @@ internal sealed partial class AddShortcutForm : FormContent
         var formUrl = formInput["url"] ?? string.Empty;
         var formSuggestionProvider = formInput["suggestionProvider"] ?? string.Empty;
         var formReplaceWhitespace = formInput["replaceWhitespace"] ?? string.Empty;
+        var formHomePage = formInput["homePage"] ?? string.Empty;
 
         var updated = _item ?? new WebSearchShortcutItem();
         updated.Name = formName.ToString();
         updated.Url = formUrl.ToString();
         updated.SuggestionProvider = formSuggestionProvider.ToString();
         updated.ReplaceWhitespace = formReplaceWhitespace.ToString();
+        updated.HomePage = formHomePage.ToString();
 
         AddedCommand?.Invoke(this, updated);
         return CommandResult.GoHome();

--- a/CmdPalWebSearchShortcut/WebSearchShortcut/Helpers/WebSearchHelper.cs
+++ b/CmdPalWebSearchShortcut/WebSearchShortcut/Helpers/WebSearchHelper.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using Microsoft.CommandPalette.Extensions.Toolkit;
+using BrowserInfo = WebSearchShortcut.Helpers.DefaultBrowserInfo;
+
+namespace WebSearchShortcut.Helpers;
+
+internal static class HomePageLauncher
+{
+    private static string GetHomePageUrl(WebSearchShortcutItem item)
+    {
+        return !string.IsNullOrWhiteSpace(item.HomePage)
+            ? item.HomePage
+            : item.Domain;
+    }
+
+    public static bool OpenHomePageWithBrowser(WebSearchShortcutItem item)
+    {
+        var homePageUrl = GetHomePageUrl(item);
+        BrowserInfo.UpdateIfTimePassed();
+        return ShellHelpers.OpenCommandInShell(
+            BrowserInfo.Path,
+            BrowserInfo.ArgumentsPattern,
+            homePageUrl
+        );
+    }
+}

--- a/CmdPalWebSearchShortcut/WebSearchShortcut/Pages/SearchPage.cs
+++ b/CmdPalWebSearchShortcut/WebSearchShortcut/Pages/SearchPage.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using Microsoft.CommandPalette.Extensions;
 using Microsoft.CommandPalette.Extensions.Toolkit;
 using WebSearchShortcut.Commands;
+using WebSearchShortcut.Helpers;
 using Windows.System;
 
 namespace WebSearchShortcut;
@@ -26,7 +27,7 @@ public partial class SearchPage : DynamicListPage
     Name = data.Name;
     Url = data.Url;
     Icon = !string.IsNullOrWhiteSpace(data.IconUrl) ? new IconInfo(data.IconUrl) : new IconInfo(IconFromUrl(Url));
-    _emptyListItem = new ListItem(new OpenDomainCommand(data));
+    _emptyListItem = new ListItem(new OpenHomePageCommand(data));
     allItems = [_emptyListItem];
 
     _lastSuggestionId = 0;
@@ -59,14 +60,7 @@ public partial class SearchPage : DynamicListPage
         MoreCommands = [new CommandContextItem(
           title: $"Open {Name}",
           name: $"Open {Name}",
-          action: () =>
-          {
-            var uri = GetUri(Item.Domain);
-            if (uri != null)
-            {
-              _ = Launcher.LaunchUriAsync(uri);
-            }
-          }
+          action: () => HomePageLauncher.OpenHomePageWithBrowser(Item)
         )]
       };
       results.Add(result);
@@ -100,14 +94,7 @@ public partial class SearchPage : DynamicListPage
         MoreCommands = [new CommandContextItem(
           title: $"Open {Name}",
           name: $"Open {Name}",
-          action: () =>
-          {
-            var uri = GetUri(Item.Domain);
-            if (uri != null)
-            {
-              _ = Launcher.LaunchUriAsync(uri);
-            }
-          }
+          action: () => HomePageLauncher.OpenHomePageWithBrowser(Item)
         )]
       })];
     List<ListItem> items = [.. queryItems, .. suggestItems];

--- a/CmdPalWebSearchShortcut/WebSearchShortcut/WebSearchShortcutItem.cs
+++ b/CmdPalWebSearchShortcut/WebSearchShortcut/WebSearchShortcutItem.cs
@@ -25,6 +25,8 @@ namespace WebSearchShortcut
 
     public string? ReplaceWhitespace { get; set; }
 
+    public string? HomePage { get; set; }
+
     [JsonIgnore]
     public string Domain
     {


### PR DESCRIPTION
### Why

Previously, the plugin used the domain from Url as the fallback homepage
when there is no search query (or <kbd>Ctrl+Enter</kbd> is pressed).  
This causes issues for some services like Google Images,  
where the root domain is not the actual homepage for the search context.

Example:
- Google Images search URL: https://www.google.com/search?udm=2&q=%s
- Actual homepage should be: https://www.google.com/imghp
- Without this fix, pressing <kbd>Ctrl+Enter</kbd> would open https://www.google.com instead.

---

### What

- Added new config field HomePage in WebSearchShortcutItem
- Updated AddShortcutForm to let users set HomePage
- Replaced OpenDomainCommand with OpenHomePageCommand
- Added HomePageLauncher helper for consistent logic
- Updated SearchPage and related command contexts to use new launcher

---

### Example config

json
{
  "Name": "Google Images",
  "Url": "https://www.google.com/search?udm=2&q=%s",
  "HomePage": "https://www.google.com/imghp"
}