### PR TITLE
fix!: generate stable IDs to avoid orphaned aliases in Command Palette

### DIFF
--- a/CmdPalWebSearchShortcut/WebSearchShortcut/Pages/SearchPage.cs
+++ b/CmdPalWebSearchShortcut/WebSearchShortcut/Pages/SearchPage.cs
@@ -7,7 +7,6 @@ using Microsoft.CommandPalette.Extensions;
 using Microsoft.CommandPalette.Extensions.Toolkit;
 using WebSearchShortcut.Commands;
 using WebSearchShortcut.Helpers;
-using Windows.System;
 
 namespace WebSearchShortcut;
 
@@ -24,6 +23,7 @@ public partial class SearchPage : DynamicListPage
   public SearchPage(WebSearchShortcutItem data)
   {
     Item = data;
+    Id = data.Id;
     Name = data.Name;
     Url = data.Url;
     Icon = !string.IsNullOrWhiteSpace(data.IconUrl) ? new IconInfo(data.IconUrl) : new IconInfo(IconFromUrl(Url));

--- a/CmdPalWebSearchShortcut/WebSearchShortcut/Storage.cs
+++ b/CmdPalWebSearchShortcut/WebSearchShortcut/Storage.cs
@@ -1,3 +1,5 @@
+using System;
+using System.Linq;
 using System.Collections.Generic;
 using System.IO;
 using System.Text.Json;
@@ -50,6 +52,11 @@ public sealed class Storage
       if (!string.IsNullOrEmpty(jsonStringReading))
       {
         data = JsonSerializer.Deserialize(jsonStringReading, AppJsonSerializerContext.Default.Storage) ?? new Storage();
+        if (data.Data.Any(item => string.IsNullOrWhiteSpace(item.Id)))
+        {
+          WriteToFile(path, data);
+          data = ReadFromFile(path);
+        }
       }
     }
 
@@ -58,8 +65,27 @@ public sealed class Storage
 
   public static void WriteToFile(string path, Storage data)
   {
+    foreach (var item in data.Data)
+    {
+      if (string.IsNullOrWhiteSpace(item.Id))
+      {
+        item.Id = GenerateNewId();
+      }
+    }
+
     var jsonString = JsonSerializer.Serialize(data, AppJsonSerializerContext.Default.Storage);
 
-    File.WriteAllText(WebSearchShortcutCommandsProvider.StateJsonPath(), jsonString);
+    File.WriteAllText(path, jsonString);
   }
+
+  private static string GenerateNewId()
+  {
+    string prefix = Windows.ApplicationModel.Package.Current.Id.FamilyName;
+
+    byte[] buffer = new byte[8];
+    Random.Shared.NextBytes(buffer);
+    ulong randomNumber = BitConverter.ToUInt64(buffer, 0);
+
+    return $"{prefix}!App!ID{randomNumber}";
+    }
 }

--- a/CmdPalWebSearchShortcut/WebSearchShortcut/WebSearchShortcutItem.cs
+++ b/CmdPalWebSearchShortcut/WebSearchShortcut/WebSearchShortcutItem.cs
@@ -1,4 +1,3 @@
-
 using System;
 using System.Net;
 using System.Text.Json.Serialization;
@@ -7,26 +6,17 @@ namespace WebSearchShortcut
 {
   public class WebSearchShortcutItem
   {
+    public string Id { get; set; } = string.Empty;
     public string Name { get; set; } = string.Empty;
-
     public string? Keyword { get; set; }
-
     public string Url { get; set; } = string.Empty;
-
     // public string[]? Urls { get; set; }
-
     public string? SuggestionProvider { get; set; }
-
     // public bool? IsDefault { get; set; }
-
     public string? IconUrl { get; set; }
-
     public string? BrowserPath { get; set; }
-
     public string? ReplaceWhitespace { get; set; }
-
     public string? HomePage { get; set; }
-
     [JsonIgnore]
     public string Domain
     {


### PR DESCRIPTION
## Why

Currently, the `Keyword` field in `WebSearchShortcutItem` is **not yet implemented**.

Users who want to invoke a search shortcut via text must rely entirely on manually setting an **alias** through the Command Palette GUI.

Once a user assigns an alias (e.g., `"google"`), the Command Palette writes an entry into the following file:

```
C:\Users\<username>\AppData\Local\Packages\Microsoft.CommandPalette_8wekyb3d8bbwe\LocalState\settings.json
```

Example structure:

```json
{
  "Aliases": {
     "google ": {
      "CommandId": "Riri.WebSearchShortcut_n7w7pg6r3cfgr!App!ID12345678901234567890",
      "Alias": "google",
      "IsDirect": false
    }
  }
}
```

This alias is tied to the `CommandId` at the time it was created.

Previously, the plugin **did not have a dedicated ID system**, and the `CommandId` was implicitly derived from `SearchPage.Name` — which is the same as `WebSearchShortcutItem.Name`.

This caused multiple issues:

* 🔁 **Multiple commands with the same name** — if assigned an alias — would cause other commands with the same name to inherit the same alias, and only one of them would actually be executed, even if they had different URLs or purposes. This also made it impossible to duplicate a command and assign two different aliases to them.
* ✏ **Renaming a command** would result in orphaned alias entries that cannot be removed or reassigned from within the plugin, and these aliases can no longer be bound to any other command — leading to unpredictable behavior or persistent conflicts in the Command Palette.

---

## What

To address these issues, we introduced a dedicated `Id` field in `WebSearchShortcutItem`, and assigned it to `SearchPage.Id` so that each command uses this stable identifier as its `CommandId` internally.

### New behavior:

* Every shortcut now gets a **stable, unique `Id`**, generated once and saved into the config file.
* This `Id` is now used as the authoritative `CommandId` when registering the command.
* This change ensures that:

  * ✅ **Aliases remain valid** even when `Name` is changed
  * ✅ **Commands with the same name** are treated as distinct entries
  * ✅ **Aliases always bind to the correct command**, based on a stable ID
* Old entries that are missing an `Id` will be automatically upgraded when the file is loaded.

---

### ⚠️ Compatibility note:

Because `CommandId` is no longer derived from `Name`, all **aliases previously created under the old Name-based system will become orphaned**.

These aliases will still exist in `settings.json`, but no longer correspond to any registered command — and because there's no public API to modify them, they will silently stop working.

This is a **necessary one-time breaking change** to ensure that aliases behave predictably and reliably going forward.

---

### 🗑 Limitation: Orphaned aliases from deleted commands still exist

Even with this new ID system, **if a user deletes a command**, the corresponding alias entry in `settings.json` will remain as an orphan.
This is a limitation of the current Command Palette system, which does not automatically remove alias mappings for missing `CommandId`.

---

### ⚠️ On possible (non-standard) solutions

Due to this update, users who have existing aliases set via the GUI will experience alias breakage after upgrading.

A **possible workaround** is to create a separate utility that edits:

```
C:\Users\<username>\AppData\Local\Packages\Microsoft.CommandPalette_8wekyb3d8bbwe\LocalState\settings.json
```

...and deletes alias entries whose `CommandId` starts with `Riri.WebSearchShortcut_n7w7pg6r3cfgr!App!ID` but no longer match any existing `Id` in the current WebSearchShortcut configuration. This would also prevent orphaned aliases from deleted commands, and furthermore, make it possible to implement the `Keyword` feature in this way.


However, this is **not a recommended or supported approach**:

* It may cause **corruption** if the format of `settings.json` changes in future Command Palette updates.
* It bypasses all built-in validation or conflict resolution.

I am still exploring safer and more user-friendly solutions.

The **ideal solution** would be to find an official way to programmatically modify aliases — it’s possible that such a method exists but has not yet been discovered.

Until then, this update and its associated tradeoffs should be carefully reviewed and discussed before being merged.