### PR TITLE
Format JSON output for readability with original characters preserved

### DIFF
--- a/CmdPalWebSearchShortcut/WebSearchShortcut/Helpers/JsonPrettyFormatter.cs
+++ b/CmdPalWebSearchShortcut/WebSearchShortcut/Helpers/JsonPrettyFormatter.cs
@@ -1,0 +1,28 @@
+﻿using System.IO;
+using System.Text;
+using System.Text.Encodings.Web;
+using System.Text.Json;
+using System.Text.Json.Serialization.Metadata;
+
+namespace WebSearchShortcut.Helpers;
+
+internal static class JsonPrettyFormatter
+{
+    private static readonly JsonWriterOptions PrettyWriterOptions = new()
+    {
+        Indented = true,
+        IndentSize = 4,
+        Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping
+    };
+
+    public static string ToPrettyJson<T>(T obj, JsonTypeInfo<T> typeInfo)
+    {
+        byte[] utf8Json = JsonSerializer.SerializeToUtf8Bytes(obj, typeInfo);
+        using JsonDocument doc = JsonDocument.Parse(utf8Json);
+        using var output = new MemoryStream();
+        using var writer = new Utf8JsonWriter(output, PrettyWriterOptions);
+        doc.RootElement.WriteTo(writer);
+        writer.Flush();
+        return Encoding.UTF8.GetString(output.ToArray());
+    }
+}

--- a/CmdPalWebSearchShortcut/WebSearchShortcut/JSONContext.cs
+++ b/CmdPalWebSearchShortcut/WebSearchShortcut/JSONContext.cs
@@ -2,7 +2,9 @@ using System.Text.Json.Serialization;
 
 namespace WebSearchShortcut;
 
-[JsonSourceGenerationOptions(IncludeFields = true)]
+[JsonSourceGenerationOptions(
+    IncludeFields = true,
+    WriteIndented = true)]
 [JsonSerializable(typeof(Storage))]
 [JsonSerializable(typeof(WebSearchShortcutItem))]
 internal partial class AppJsonSerializerContext : JsonSerializerContext

--- a/CmdPalWebSearchShortcut/WebSearchShortcut/JSONContext.cs
+++ b/CmdPalWebSearchShortcut/WebSearchShortcut/JSONContext.cs
@@ -2,9 +2,7 @@ using System.Text.Json.Serialization;
 
 namespace WebSearchShortcut;
 
-[JsonSourceGenerationOptions(
-    IncludeFields = true,
-    WriteIndented = true)]
+[JsonSourceGenerationOptions(IncludeFields = true)]
 [JsonSerializable(typeof(Storage))]
 [JsonSerializable(typeof(WebSearchShortcutItem))]
 internal partial class AppJsonSerializerContext : JsonSerializerContext

--- a/CmdPalWebSearchShortcut/WebSearchShortcut/Storage.cs
+++ b/CmdPalWebSearchShortcut/WebSearchShortcut/Storage.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Text.Json;
+using WebSearchShortcut.Helpers;
 
 namespace WebSearchShortcut;
 
@@ -58,7 +59,7 @@ public sealed class Storage
 
   public static void WriteToFile(string path, Storage data)
   {
-    var jsonString = JsonSerializer.Serialize(data, AppJsonSerializerContext.Default.Storage);
+    var jsonString = JsonPrettyFormatter.ToPrettyJson(data, AppJsonSerializerContext.Default.Storage);
 
     File.WriteAllText(WebSearchShortcutCommandsProvider.StateJsonPath(), jsonString);
   }


### PR DESCRIPTION
### Why

Previously, the plugin used `JsonSerializer.Serialize(...)` to save config files like `WebSearchShortcut.json`,
which generated compact JSON with escaped characters such as `\u0022` (for `"`) and `\u0026` (for `&`).

This made the file difficult to read and manually edit — especially for URLs or non-ASCII characters like Chinese.
The escaped format is not ideal for tools or users who expect the original, readable characters.

Example (before):

```json
{"Name":"\u8C37\u6B4C","Url":"https://www.google.com/search?udm=14\u0026q=%s","BrowserArgs":"--profile-directory=\u0022Default\u0022"}
```

---

### What

* Added a `JsonPrettyFormatter` utility to output formatted, readable JSON
* Enabled relaxed escaping to preserve original characters (e.g. `"` and `&`)
* Replaced all usages of `JsonSerializer.Serialize(...)` with `JsonPrettyFormatter.ToPrettyJson(...)` when saving config

---

### Example output (after)

```json
{
    "Name": "谷歌",
    "Url": "https://www.google.com/search?udm=14&q=%s",
    "BrowserArgs": "--profile-directory=\"Default\""
}
```

---

### Benefits

* ✅ Cleaner and more readable config files
* ✅ Preserves original characters instead of using escape sequences
* ✅ Easier for users to understand or modify configs directly