### PR TITLE
feat!: include OpenHomePageCommand in each shortcut’s MoreCommands

### DIFF
--- a/CmdPalWebSearchShortcut/WebSearchShortcut/WebSearchShortcutCommandsProvider.cs
+++ b/CmdPalWebSearchShortcut/WebSearchShortcut/WebSearchShortcutCommandsProvider.cs
@@ -9,6 +9,7 @@ using System.IO;
 using System.Linq;
 using Microsoft.CommandPalette.Extensions;
 using Microsoft.CommandPalette.Extensions.Toolkit;
+using WebSearchShortcut.Commands;
 using WebSearchShortcut.Helpers;
 using WebSearchShortcut.Properties;
 using WebSearchShortcut.Services;
@@ -131,6 +132,17 @@ public partial class WebSearchShortcutCommandsProvider : CommandProvider
 
     private CommandItem CreateCommandItem(WebSearchShortcutDataEntry shortcut)
     {
+        var openHomepageCommand = new CommandContextItem(
+            new OpenHomePageCommand(shortcut)
+            {
+                Name = StringFormatter.Format(Resources.OpenHomepageItem_NameTemplate, new() { ["shortcut"] = shortcut.Name })
+            }
+        )
+        {
+            Title = StringFormatter.Format(Resources.OpenHomepageItem_TitleTemplate, new() { ["shortcut"] = shortcut.Name }),
+            Icon = Icons.Home
+        };
+
         var editShortcutPage = new AddShortcutPage(shortcut)
         {
             Name = StringFormatter.Format(Resources.EditShortcutItem_NameTemplate, new() { ["shortcut"] = shortcut.Name }),
@@ -173,7 +185,7 @@ public partial class WebSearchShortcutCommandsProvider : CommandProvider
             Title = StringFormatter.Format(Resources.ShortcutItem_TitleTemplate, new() { ["shortcut"] = shortcut.Name }),
             Subtitle = StringFormatter.Format(Resources.ShortcutItem_SubtitleTemplate, new() { ["shortcut"] = shortcut.Name }),
             Icon = IconService.GetIconInfo(shortcut),
-            MoreCommands = [editCommand, deleteCommand]
+            MoreCommands = [openHomepageCommand, editCommand, deleteCommand]
         };
 
         return commandItem;


### PR DESCRIPTION
**Summary**

* Add `OpenHomePageCommand` to every top-level shortcut’s `CommandItem.MoreCommands`, so users can open the engine’s homepage right from the list (e.g., press Ctrl+Enter) without entering the shortcut.
* Change `OpenHomePageCommand` icon to a Home symbol for clearer affordance (was Search).

**Notes**

* If you believe quick editing is more valuable for newcomers, feel free to skip this PR.