### PR TITLE
Feature/history

### DIFF
--- a/CmdPalWebSearchShortcut/WebSearchShortcut/Commands/OpenHomePageCommand.cs
+++ b/CmdPalWebSearchShortcut/WebSearchShortcut/Commands/OpenHomePageCommand.cs
@@ -1,7 +1,5 @@
 using Microsoft.CommandPalette.Extensions.Toolkit;
 using WebSearchShortcut.Browsers;
-using WebSearchShortcut.Helpers;
-using WebSearchShortcut.Properties;
 
 namespace WebSearchShortcut.Commands;
 
@@ -12,8 +10,8 @@ internal sealed partial class OpenHomePageCommand : InvokableCommand
 
     internal OpenHomePageCommand(WebSearchShortcutDataEntry shortcut)
     {
-        Name = StringFormatter.Format(Resources.OpenHomePage_NameTemplate, new() { ["engine"] = shortcut.Name });
-        Icon = Icons.Search;
+        Name = $"[UNBOUND] {nameof(OpenHomePageCommand)}.{nameof(Name)} required - shortcut='{shortcut.Name}'";
+
         _shortcut = shortcut;
         _browserInfo = new BrowserExecutionInfo(shortcut);
     }

--- a/CmdPalWebSearchShortcut/WebSearchShortcut/Commands/SearchWebCommand.cs
+++ b/CmdPalWebSearchShortcut/WebSearchShortcut/Commands/SearchWebCommand.cs
@@ -1,5 +1,6 @@
 using Microsoft.CommandPalette.Extensions.Toolkit;
 using WebSearchShortcut.Browsers;
+using WebSearchShortcut.History;
 
 namespace WebSearchShortcut.Commands;
 
@@ -27,6 +28,8 @@ internal sealed partial class SearchWebCommand : InvokableCommand
             // TODO GH# 138 --> actually display feedback from the extension somewhere.
             return CommandResult.KeepOpen();
         }
+
+        HistoryService.Add(_shortcut.Name, _query);
 
         // if (_settingsManager.ShowHistory != Resources.history_none)
         // {

--- a/CmdPalWebSearchShortcut/WebSearchShortcut/Commands/SearchWebCommand.cs
+++ b/CmdPalWebSearchShortcut/WebSearchShortcut/Commands/SearchWebCommand.cs
@@ -1,7 +1,5 @@
 using Microsoft.CommandPalette.Extensions.Toolkit;
 using WebSearchShortcut.Browsers;
-using WebSearchShortcut.Helpers;
-using WebSearchShortcut.Properties;
 
 namespace WebSearchShortcut.Commands;
 
@@ -14,8 +12,8 @@ internal sealed partial class SearchWebCommand : InvokableCommand
 
     public SearchWebCommand(WebSearchShortcutDataEntry shortcut, string query)
     {
-        Name = StringFormatter.Format(Resources.SearchQuery_NameTemplate, new() { ["engine"] = shortcut.Name, ["query"] = query });
-        Icon = Icons.Search;
+        Name = $"[UNBOUND] {nameof(SearchWebCommand)}.{nameof(Name)} required - shortcut='{shortcut.Name}', query='{query}'";
+
         _query = query;
         _shortcut = shortcut;
         _browserInfo = new BrowserExecutionInfo(shortcut);

--- a/CmdPalWebSearchShortcut/WebSearchShortcut/Commands/SearchWebCommand.cs
+++ b/CmdPalWebSearchShortcut/WebSearchShortcut/Commands/SearchWebCommand.cs
@@ -18,7 +18,6 @@ internal sealed partial class SearchWebCommand : InvokableCommand
         _query = query;
         _shortcut = shortcut;
         _browserInfo = new BrowserExecutionInfo(shortcut);
-        // _settingsManager = settingsManager;
     }
 
     public override CommandResult Invoke()
@@ -29,12 +28,8 @@ internal sealed partial class SearchWebCommand : InvokableCommand
             return CommandResult.KeepOpen();
         }
 
-        HistoryService.Add(_shortcut.Name, _query);
-
-        // if (_settingsManager.ShowHistory != Resources.history_none)
-        // {
-        //   _settingsManager.SaveHistory(new HistoryItem(Arguments, DateTime.Now));
-        // }
+        if (_shortcut.RecordHistory ?? true)
+            HistoryService.Add(_shortcut.Name, _query);
 
         return CommandResult.Dismiss();
     }

--- a/CmdPalWebSearchShortcut/WebSearchShortcut/Forms/AddShortcutForm.cs
+++ b/CmdPalWebSearchShortcut/WebSearchShortcut/Forms/AddShortcutForm.cs
@@ -32,29 +32,29 @@ internal sealed partial class AddShortcutForm : FormContent
         {
             "id": "name",
             "type": "Input.Text",
-            "label": {{JsonSerializer.Serialize(Resources.AddShortcutForm_NameLabel, AppJsonSerializerContext.Default.String)}},
+            "label": {{JsonSerializer.Serialize(Resources.AddShortcutForm_Name_Label, AppJsonSerializerContext.Default.String)}},
             "value": {{JsonSerializer.Serialize(name, AppJsonSerializerContext.Default.String)}},
             "isRequired": true,
-            "errorMessage": {{JsonSerializer.Serialize(Resources.AddShortcutForm_NameErrorMessage, AppJsonSerializerContext.Default.String)}}
+            "errorMessage": {{JsonSerializer.Serialize(Resources.AddShortcutForm_Name_ErrorMessage, AppJsonSerializerContext.Default.String)}}
         },
         {
             "id": "url",
             "type": "Input.Text",
             "style": "Url",
-            "label": {{JsonSerializer.Serialize(Resources.AddShortcutForm_UrlLabel, AppJsonSerializerContext.Default.String)}},
-            "placeholder": {{JsonSerializer.Serialize(Resources.AddShortcutForm_UrlPlaceholder, AppJsonSerializerContext.Default.String)}},
+            "label": {{JsonSerializer.Serialize(Resources.AddShortcutForm_Url_Label, AppJsonSerializerContext.Default.String)}},
+            "placeholder": {{JsonSerializer.Serialize(Resources.AddShortcutForm_Url_Placeholder, AppJsonSerializerContext.Default.String)}},
             "value": {{JsonSerializer.Serialize(url, AppJsonSerializerContext.Default.String)}},
             "isRequired": true,
-            "errorMessage": {{JsonSerializer.Serialize(Resources.AddShortcutForm_UrlErrorMessage, AppJsonSerializerContext.Default.String)}}
+            "errorMessage": {{JsonSerializer.Serialize(Resources.AddShortcutForm_Url_ErrorMessage, AppJsonSerializerContext.Default.String)}}
         },
         {
             "id": "suggestionProvider",
             "type": "Input.ChoiceSet",
-            "label": {{JsonSerializer.Serialize(Resources.AddShortcutForm_SuggestionProviderLabel, AppJsonSerializerContext.Default.String)}},
-            "placeholder": {{JsonSerializer.Serialize(Resources.AddShortcutForm_SuggestionProviderPlaceholder, AppJsonSerializerContext.Default.String)}},
+            "label": {{JsonSerializer.Serialize(Resources.AddShortcutForm_SuggestionProvider_Label, AppJsonSerializerContext.Default.String)}},
+            "placeholder": {{JsonSerializer.Serialize(Resources.AddShortcutForm_SuggestionProvider_Placeholder, AppJsonSerializerContext.Default.String)}},
             "choices": [
                 {
-                    "title": {{JsonSerializer.Serialize(Resources.AddShortcutForm_SuggestionProviderNone, AppJsonSerializerContext.Default.String)}},
+                    "title": {{JsonSerializer.Serialize(Resources.AddShortcutForm_SuggestionProvider_None, AppJsonSerializerContext.Default.String)}},
                     "value": ""
                 },
                 {{SuggestionsRegistry.ProviderNames.Select(key => $$"""
@@ -71,8 +71,8 @@ internal sealed partial class AddShortcutForm : FormContent
             "type": "Input.Text",
             "style": "text",
             "id": "replaceWhitespace",
-            "label": {{JsonSerializer.Serialize(Resources.AddShortcutForm_ReplaceWhitespaceLabel, AppJsonSerializerContext.Default.String)}},
-            "placeholder": {{JsonSerializer.Serialize(Resources.AddShortcutForm_ReplaceWhitespacePlaceholder, AppJsonSerializerContext.Default.String)}},
+            "label": {{JsonSerializer.Serialize(Resources.AddShortcutForm_ReplaceWhitespace_Label, AppJsonSerializerContext.Default.String)}},
+            "placeholder": {{JsonSerializer.Serialize(Resources.AddShortcutForm_ReplaceWhitespace_Placeholder, AppJsonSerializerContext.Default.String)}},
             "value": {{JsonSerializer.Serialize(replaceWhitespace, AppJsonSerializerContext.Default.String)}},
             "errorMessage": "// Just for space between items"
         },
@@ -80,19 +80,19 @@ internal sealed partial class AddShortcutForm : FormContent
             "type": "Input.Text",
             "style": "text",
             "id": "homePage",
-            "label": {{JsonSerializer.Serialize(Resources.AddShortcutForm_HomepageLabel, AppJsonSerializerContext.Default.String)}},
-            "placeholder": {{JsonSerializer.Serialize(Resources.AddShortcutForm_HomepagePlaceholder, AppJsonSerializerContext.Default.String)}},
+            "label": {{JsonSerializer.Serialize(Resources.AddShortcutForm_Homepage_Label, AppJsonSerializerContext.Default.String)}},
+            "placeholder": {{JsonSerializer.Serialize(Resources.AddShortcutForm_Homepage_Placeholder, AppJsonSerializerContext.Default.String)}},
             "value": {{JsonSerializer.Serialize(homePage, AppJsonSerializerContext.Default.String)}},
             "errorMessage": "// Just for space between items"
         },
         {
             "id": "browserPath",
             "type": "Input.ChoiceSet",
-            "label": {{JsonSerializer.Serialize(Resources.AddShortcutForm_BrowserPathLabel, AppJsonSerializerContext.Default.String)}},
+            "label": {{JsonSerializer.Serialize(Resources.AddShortcutForm_BrowserPath_Label, AppJsonSerializerContext.Default.String)}},
             "placeholder": {{JsonSerializer.Serialize(browserPath, AppJsonSerializerContext.Default.String)}},
             "choices": [
                 {
-                    "title": {{JsonSerializer.Serialize(Resources.AddShortcutForm_BrowserPathDefault, AppJsonSerializerContext.Default.String)}},
+                    "title": {{JsonSerializer.Serialize(Resources.AddShortcutForm_BrowserPath_Default, AppJsonSerializerContext.Default.String)}},
                     "value": ""
                 },
                 {{BrowserDiscovery.GetAllInstalledBrowsers()
@@ -112,8 +112,8 @@ internal sealed partial class AddShortcutForm : FormContent
             "id": "browserArgs",
             "type": "Input.Text",
             "style": "text",
-            "label": {{JsonSerializer.Serialize(Resources.AddShortcutForm_BrowserArgsLabel, AppJsonSerializerContext.Default.String)}},
-            "placeholder": {{JsonSerializer.Serialize(Resources.AddShortcutForm_BrowserArgsPlaceholder, AppJsonSerializerContext.Default.String)}},
+            "label": {{JsonSerializer.Serialize(Resources.AddShortcutForm_BrowserArgs_Label, AppJsonSerializerContext.Default.String)}},
+            "placeholder": {{JsonSerializer.Serialize(Resources.AddShortcutForm_BrowserArgs_Placeholder, AppJsonSerializerContext.Default.String)}},
             "value": {{JsonSerializer.Serialize(browserArgs, AppJsonSerializerContext.Default.String)}},
             "errorMessage": "// Just for space between items"
         }

--- a/CmdPalWebSearchShortcut/WebSearchShortcut/Forms/AddShortcutForm.cs
+++ b/CmdPalWebSearchShortcut/WebSearchShortcut/Forms/AddShortcutForm.cs
@@ -57,32 +57,32 @@ internal sealed partial class AddShortcutForm : FormContent
                     "title": {{JsonSerializer.Serialize(Resources.AddShortcutForm_SuggestionProvider_None, AppJsonSerializerContext.Default.String)}},
                     "value": ""
                 },
-                {{SuggestionsRegistry.ProviderNames.Select(key => $$"""
+{{SuggestionsRegistry.ProviderNames.Select(key => $$"""
                 {
                     "title": {{JsonSerializer.Serialize(key, AppJsonSerializerContext.Default.String)}},
                     "value": {{JsonSerializer.Serialize(key, AppJsonSerializerContext.Default.String)}}
                 }
-                """).Aggregate((a, b) => a + "," + b)}}
+""")
+    .Aggregate((a, b) => a + ",\n" + b)}}
             ],
             "value": {{JsonSerializer.Serialize(suggestionProvider, AppJsonSerializerContext.Default.String)}},
             "errorMessage": "// Just for space between items"
         },
         {
-            "type": "Input.Text",
-            "style": "text",
-            "id": "replaceWhitespace",
-            "label": {{JsonSerializer.Serialize(Resources.AddShortcutForm_ReplaceWhitespace_Label, AppJsonSerializerContext.Default.String)}},
-            "placeholder": {{JsonSerializer.Serialize(Resources.AddShortcutForm_ReplaceWhitespace_Placeholder, AppJsonSerializerContext.Default.String)}},
-            "value": {{JsonSerializer.Serialize(replaceWhitespace, AppJsonSerializerContext.Default.String)}},
-            "errorMessage": "// Just for space between items"
-        },
-        {
-            "type": "Input.Text",
-            "style": "text",
             "id": "homePage",
+            "type": "Input.Text",
+            "style": "Url",
             "label": {{JsonSerializer.Serialize(Resources.AddShortcutForm_Homepage_Label, AppJsonSerializerContext.Default.String)}},
             "placeholder": {{JsonSerializer.Serialize(Resources.AddShortcutForm_Homepage_Placeholder, AppJsonSerializerContext.Default.String)}},
             "value": {{JsonSerializer.Serialize(homePage, AppJsonSerializerContext.Default.String)}},
+            "errorMessage": "// Just for space between items"
+        },
+        {
+            "id": "replaceWhitespace",
+            "type": "Input.Text",
+            "label": {{JsonSerializer.Serialize(Resources.AddShortcutForm_ReplaceWhitespace_Label, AppJsonSerializerContext.Default.String)}},
+            "placeholder": {{JsonSerializer.Serialize(Resources.AddShortcutForm_ReplaceWhitespace_Placeholder, AppJsonSerializerContext.Default.String)}},
+            "value": {{JsonSerializer.Serialize(replaceWhitespace, AppJsonSerializerContext.Default.String)}},
             "errorMessage": "// Just for space between items"
         },
         {
@@ -95,15 +95,15 @@ internal sealed partial class AddShortcutForm : FormContent
                     "title": {{JsonSerializer.Serialize(Resources.AddShortcutForm_BrowserPath_Default, AppJsonSerializerContext.Default.String)}},
                     "value": ""
                 },
-                {{BrowserDiscovery.GetAllInstalledBrowsers()
-                        .Where(b => !string.IsNullOrWhiteSpace(b.Path))
-                        .Select(b => $$"""
-                        {
-                            "title": {{JsonSerializer.Serialize(b.Name, AppJsonSerializerContext.Default.String)}},
-                            "value": {{JsonSerializer.Serialize(b.Path, AppJsonSerializerContext.Default.String)}}
-                        }
-                        """)
-                        .Aggregate((a, b) => a + "," + b)}}
+{{BrowserDiscovery.GetAllInstalledBrowsers()
+    .Where(b => !string.IsNullOrWhiteSpace(b.Path))
+    .Select(b => $$"""
+                {
+                    "title": {{JsonSerializer.Serialize(b.Name, AppJsonSerializerContext.Default.String)}},
+                    "value": {{JsonSerializer.Serialize(b.Path, AppJsonSerializerContext.Default.String)}}
+                }
+""")
+    .Aggregate((a, b) => a + ",\n" + b)}}
             ],
             "value": {{JsonSerializer.Serialize(browserPath, AppJsonSerializerContext.Default.String)}},
             "errorMessage": "// Just for space between items"
@@ -111,7 +111,6 @@ internal sealed partial class AddShortcutForm : FormContent
         {
             "id": "browserArgs",
             "type": "Input.Text",
-            "style": "text",
             "label": {{JsonSerializer.Serialize(Resources.AddShortcutForm_BrowserArgs_Label, AppJsonSerializerContext.Default.String)}},
             "placeholder": {{JsonSerializer.Serialize(Resources.AddShortcutForm_BrowserArgs_Placeholder, AppJsonSerializerContext.Default.String)}},
             "value": {{JsonSerializer.Serialize(browserArgs, AppJsonSerializerContext.Default.String)}},

--- a/CmdPalWebSearchShortcut/WebSearchShortcut/Forms/AddShortcutForm.cs
+++ b/CmdPalWebSearchShortcut/WebSearchShortcut/Forms/AddShortcutForm.cs
@@ -1,8 +1,9 @@
+using System;
 using System.Linq;
 using System.Text.Json;
 using System.Text.Json.Nodes;
-using Microsoft.CommandPalette.Extensions.Toolkit;
 using Windows.Foundation;
+using Microsoft.CommandPalette.Extensions.Toolkit;
 using WebSearchShortcut.Browsers;
 using WebSearchShortcut.Properties;
 
@@ -19,6 +20,7 @@ internal sealed partial class AddShortcutForm : FormContent
         var url = shortcut?.Url ?? string.Empty;
         var suggestionProvider = shortcut?.SuggestionProvider ?? string.Empty;
         var replaceWhitespace = shortcut?.ReplaceWhitespace ?? string.Empty;
+        var recordHistory = shortcut?.RecordHistory ?? true;
         var homePage = shortcut?.HomePage ?? string.Empty;
         var browserPath = shortcut?.BrowserPath ?? string.Empty;
         var browserArgs = shortcut?.BrowserArgs ?? string.Empty;
@@ -67,6 +69,13 @@ internal sealed partial class AddShortcutForm : FormContent
             ],
             "value": {{JsonSerializer.Serialize(suggestionProvider, AppJsonSerializerContext.Default.String)}},
             "errorMessage": "// Just for space between items"
+        },
+        {
+            "id": "recordHistory",
+            "type": "Input.Toggle",
+            "label": {{JsonSerializer.Serialize(Resources.AddShortcutForm_RecordHistory_Label, AppJsonSerializerContext.Default.String)}},
+            "title": {{JsonSerializer.Serialize(Resources.AddShortcutForm_RecordHistory_Title, AppJsonSerializerContext.Default.String)}},
+            "value": {{JsonSerializer.Serialize(recordHistory ? "true" : "false", AppJsonSerializerContext.Default.String)}}
         },
         {
             "id": "homePage",
@@ -126,6 +135,7 @@ internal sealed partial class AddShortcutForm : FormContent
                 "url": "url",
                 "suggestionProvider": "suggestionProvider",
                 "replaceWhitespace": "replaceWhitespace",
+                "recordHistory": "recordHistory",
                 "homePage": "homePage",
                 "browserPath": "browserPath",
                 "browserArgs": "browserArgs"
@@ -148,11 +158,13 @@ internal sealed partial class AddShortcutForm : FormContent
         shortcut.Url = root["url"]?.GetValue<string>() ?? string.Empty;
         shortcut.SuggestionProvider = root["suggestionProvider"]?.GetValue<string>() ?? string.Empty;
         shortcut.ReplaceWhitespace = root["replaceWhitespace"]?.GetValue<string>() ?? string.Empty;
+        shortcut.RecordHistory = string.Equals(root["recordHistory"]?.GetValue<string>() ?? "true", "true", StringComparison.OrdinalIgnoreCase);
         shortcut.HomePage = root["homePage"]?.GetValue<string>() ?? string.Empty;
         shortcut.BrowserPath = root["browserPath"]?.GetValue<string>() ?? string.Empty;
         shortcut.BrowserArgs = root["browserArgs"]?.GetValue<string>() ?? string.Empty;
 
         AddedCommand?.Invoke(this, shortcut);
+
         return CommandResult.GoHome();
     }
 }

--- a/CmdPalWebSearchShortcut/WebSearchShortcut/Helpers/IntSetting.cs
+++ b/CmdPalWebSearchShortcut/WebSearchShortcut/Helpers/IntSetting.cs
@@ -1,0 +1,77 @@
+﻿using System.Collections.Generic;
+using System.Text.Json.Nodes;
+
+namespace Microsoft.CommandPalette.Extensions.Toolkit;
+
+public sealed class IntSetting : Setting<int>
+{
+    public int? Min { get; set; }
+    public int? Max { get; set; }
+    public string Placeholder { get; set; } = string.Empty;
+
+    private IntSetting()
+        : base()
+    {
+        Value = 0;
+    }
+
+    public IntSetting(string key, int defaultValue, int? min = null, int? max = null)
+        : base(key, defaultValue)
+    {
+        Min = min;
+        Max = max;
+    }
+
+    public IntSetting(string key, string label, string description, int defaultValue,
+                      int? min = null, int? max = null)
+        : base(key, label, description, defaultValue)
+    {
+        Min = min;
+        Max = max;
+    }
+
+    public override Dictionary<string, object> ToDictionary()
+    {
+        var dict = new Dictionary<string, object>
+        {
+            { "id", Key },
+            { "type", "Input.Number" },
+            { "title", Label },
+            { "label", Description },
+            { "value", Value },
+            { "isRequired", IsRequired },
+            { "errorMessage", ErrorMessage },
+            { "placeholder", Placeholder },
+        };
+
+        if (Min.HasValue) dict["min"] = Min.Value;
+        if (Max.HasValue) dict["max"] = Max.Value;
+
+        return dict;
+    }
+
+    public static IntSetting LoadFromJson(JsonObject jsonObject) => new() { Value = jsonObject["value"]?.GetValue<int>() ?? 0 };
+
+    public override void Update(JsonObject payload)
+    {
+        if (payload.TryGetPropertyValue(Key, out JsonNode? node) && node is not null)
+        {
+            if (node is JsonValue jsonValue && jsonValue.TryGetValue<int>(out var value))
+            {
+                Value = value;
+            }
+            else if (int.TryParse(node.ToString(), out value))
+            {
+                Value = value;
+            }
+        }
+
+        if (Min.HasValue && Value < Min.Value) Value = Min.Value;
+        if (Max.HasValue && Value > Max.Value) Value = Max.Value;
+    }
+
+    public override string ToState()
+    {
+        return $"\"{Key}\": {Value}";
+    }
+}

--- a/CmdPalWebSearchShortcut/WebSearchShortcut/Helpers/SettingsManager.cs
+++ b/CmdPalWebSearchShortcut/WebSearchShortcut/Helpers/SettingsManager.cs
@@ -1,0 +1,63 @@
+﻿using System.IO;
+using Windows.Foundation;
+using Microsoft.CommandPalette.Extensions.Toolkit;
+using WebSearchShortcut.Properties;
+
+namespace WebSearchShortcut.Helpers;
+
+internal class SettingsManager : JsonSettingsManager
+{
+    private const string _namespace = "WebSearchShortcut";
+    private static string Namespaced(string propertyName) => $"{_namespace}.{propertyName}";
+
+    private const int _defaultMaxDisplayCount = 20;
+    private const int _defaultMaxHistoryDisplayCount = 3;
+
+    private readonly IntSetting _maxDisplayCount = new(
+        Namespaced(nameof(MaxDisplayCount)),
+        Resources.Settings_MaxDisplayCount_Label,
+        Resources.Settings_MaxDisplayCount_Description,
+        _defaultMaxDisplayCount,
+        1, null
+    )
+    { ErrorMessage = Resources.Settings_MaxDisplayCount_ErrorMessage };
+
+    private readonly IntSetting _maxHistoryDisplayCount = new(
+        Namespaced(nameof(MaxHistoryDisplayCount)),
+        Resources.Settings_MaxHistoryDisplayCount_Label,
+        Resources.Settings_MaxHistoryDisplayCount_Description,
+        _defaultMaxHistoryDisplayCount,
+        0, null
+    )
+    { ErrorMessage = Resources.Settings_MaxHistoryDisplayCount_ErrorMessage };
+
+    public int MaxDisplayCount => _maxDisplayCount.Value;
+    public int MaxHistoryDisplayCount => _maxHistoryDisplayCount.Value;
+
+    public event TypedEventHandler<object, Settings>? SettingsChanged
+    {
+        add => Settings.SettingsChanged += value;
+        remove => Settings.SettingsChanged -= value;
+    }
+
+    internal static string SettingsJsonPath()
+    {
+        var directory = Utilities.BaseSettingsPath("Microsoft.CmdPal");
+
+        Directory.CreateDirectory(directory);
+
+        return Path.Combine(directory, "settings.json");
+    }
+
+    public SettingsManager()
+    {
+        FilePath = SettingsJsonPath();
+
+        Settings.Add(_maxDisplayCount);
+        Settings.Add(_maxHistoryDisplayCount);
+
+        LoadSettings();
+
+        Settings.SettingsChanged += (s, a) => SaveSettings();
+    }
+}

--- a/CmdPalWebSearchShortcut/WebSearchShortcut/History/HistoryEntry.cs
+++ b/CmdPalWebSearchShortcut/WebSearchShortcut/History/HistoryEntry.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Text.Json.Serialization;
+
+namespace WebSearchShortcut.History;
+
+internal sealed record HistoryEntry
+{
+    public string Query { get; init; }
+    public DateTimeOffset Timestamp { get; init; }
+
+    [JsonConstructor]
+    public HistoryEntry(string query, DateTimeOffset timestamp)
+        => (Query, Timestamp) = (query, timestamp);
+
+    public HistoryEntry(string query) : this(query, DateTimeOffset.UtcNow) { }
+}

--- a/CmdPalWebSearchShortcut/WebSearchShortcut/History/HistoryService.cs
+++ b/CmdPalWebSearchShortcut/WebSearchShortcut/History/HistoryService.cs
@@ -1,0 +1,113 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using Microsoft.CommandPalette.Extensions;
+using Microsoft.CommandPalette.Extensions.Toolkit;
+
+namespace WebSearchShortcut.History;
+
+internal static class HistoryService
+{
+    public static string HistoryFilePath
+    {
+        get
+        {
+            var directory = Utilities.BaseSettingsPath("WebSearchShortcut");
+
+            Directory.CreateDirectory(directory);
+
+            return Path.Combine(directory, "WebSearchShortcut_history.json");
+        }
+    }
+
+    private static readonly HistoryStorage _cache = new();
+    private static readonly Dictionary<string, string[]> _shortcutQueriesMap = new(StringComparer.OrdinalIgnoreCase);
+    private static readonly Lock _lock = new();
+
+    static HistoryService()
+    {
+        Reload();
+    }
+
+    public static string[] Get(string shortcutName)
+    {
+        lock (_lock)
+        {
+            return [.. _shortcutQueriesMap.GetValueOrDefault(shortcutName, [])];
+        }
+    }
+
+    public static void Add(string shortcutName, string query)
+    {
+        lock (_lock)
+        {
+            if (!_cache.Data.TryGetValue(shortcutName, out var entries) || entries is null)
+                _cache.Data[shortcutName] = entries = [];
+
+            entries.Insert(0, new HistoryEntry(query));
+
+            RebuildShortcutQueriesMap();
+
+            Save();
+
+            ExtensionHost.LogMessage($"[WebSearchShortcut] History: Add Query shortcut=\"{shortcutName}\" query=\"{query}\"");
+        }
+    }
+
+    public static void Reload()
+    {
+        lock (_lock)
+        {
+            HistoryStorage storage;
+            try
+            {
+                storage = HistoryStorage.ReadFromFile(HistoryFilePath);
+            }
+            catch (Exception ex)
+            {
+                ExtensionHost.LogMessage(new LogMessage() { Message = $"[WebSearchShortcut] History: Reload failed: {ex}", State = MessageState.Error });
+
+                return;
+            }
+
+            _cache.Data = storage?.Data ?? new Dictionary<string, List<HistoryEntry>>(StringComparer.OrdinalIgnoreCase);
+
+            RebuildShortcutQueriesMap();
+
+            ExtensionHost.LogMessage($"[WebSearchShortcut] History: Reload succeeded");
+        }
+    }
+
+    private static void Save()
+    {
+        try
+        {
+            HistoryStorage.WriteToFile(HistoryFilePath, _cache);
+        }
+        catch (Exception ex)
+        {
+            ExtensionHost.LogMessage(new LogMessage() { Message = $"[WebSearchShortcut] History: Save failed: {ex}", State = MessageState.Error });
+
+            return;
+        }
+
+        ExtensionHost.LogMessage($"[WebSearchShortcut] History: Save succeeded");
+    }
+
+    private static void RebuildShortcutQueriesMap()
+    {
+        _shortcutQueriesMap.Clear();
+
+        foreach (var (shortcutName, historyEntries) in _cache.Data)
+        {
+            _shortcutQueriesMap[shortcutName] = [
+                .. (historyEntries ?? Enumerable.Empty<HistoryEntry>())
+                    .OrderByDescending(entry => entry.Timestamp)
+                    .Select(entry => entry.Query)
+                    .Distinct(StringComparer.OrdinalIgnoreCase)
+            ];
+        }
+    }
+}

--- a/CmdPalWebSearchShortcut/WebSearchShortcut/History/HistoryService.cs
+++ b/CmdPalWebSearchShortcut/WebSearchShortcut/History/HistoryService.cs
@@ -39,6 +39,17 @@ internal static class HistoryService
         }
     }
 
+    public static string[] Search(string shortcutName, string searchText)
+    {
+        lock (_lock)
+        {
+            return [
+                .. Get(shortcutName)
+                    .Where(query => query.StartsWith(searchText, StringComparison.OrdinalIgnoreCase))
+            ];
+        }
+    }
+
     public static void Add(string shortcutName, string query)
     {
         lock (_lock)

--- a/CmdPalWebSearchShortcut/WebSearchShortcut/History/HistoryService.cs
+++ b/CmdPalWebSearchShortcut/WebSearchShortcut/History/HistoryService.cs
@@ -56,6 +56,37 @@ internal static class HistoryService
         }
     }
 
+    public static void Remove(string shortcutName, string query)
+    {
+        lock (_lock)
+        {
+            if (!_cache.Data.TryGetValue(shortcutName, out var entries) || entries is null)
+                return;
+
+            entries.RemoveAll(entry => string.Equals(entry.Query, query, StringComparison.Ordinal));
+
+            RebuildShortcutQueriesMap();
+
+            Save();
+
+            ExtensionHost.LogMessage($"[WebSearchShortcut] History: Delete Query shortcut=\"{shortcutName}\" query=\"{query}\"");
+        }
+    }
+
+    public static void RemoveAll(string shortcutName)
+    {
+        lock (_lock)
+        {
+            _cache.Data[shortcutName] = [];
+
+            RebuildShortcutQueriesMap();
+
+            Save();
+
+            ExtensionHost.LogMessage($"[WebSearchShortcut] History: Claer shortcut=\"{shortcutName}\"");
+        }
+    }
+
     public static void Reload()
     {
         lock (_lock)

--- a/CmdPalWebSearchShortcut/WebSearchShortcut/History/HistoryStorage.cs
+++ b/CmdPalWebSearchShortcut/WebSearchShortcut/History/HistoryStorage.cs
@@ -1,0 +1,71 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text.Json;
+using WebSearchShortcut.Helpers;
+
+using Microsoft.CommandPalette.Extensions.Toolkit;
+
+namespace WebSearchShortcut.History;
+
+internal sealed class HistoryStorage
+{
+    public Dictionary<string, List<HistoryEntry>> Data { get; set; } = [];
+
+    public static HistoryStorage ReadFromFile(string path)
+    {
+        if (!File.Exists(path))
+        {
+            HistoryStorage empty = new();
+
+            WriteToFile(path, empty);
+
+            return empty;
+        }
+
+        string jsonString;
+
+        try
+        {
+            jsonString = File.ReadAllText(path);
+        }
+        catch (Exception ex)
+        {
+            ExtensionHost.LogMessage($"[HistoryStorage] ReadFile failed: {ex.GetType().Name}: {ex.Message}");
+
+            throw;
+        }
+
+        if (string.IsNullOrWhiteSpace(jsonString))
+        {
+            return new HistoryStorage();
+        }
+
+        try
+        {
+            return JsonSerializer.Deserialize(jsonString, AppJsonSerializerContext.Default.HistoryStorage) ?? new HistoryStorage();
+        }
+        catch (Exception ex)
+        {
+            ExtensionHost.LogMessage($"[HistoryStorage] JsonDeserialize failed: {ex.GetType().Name}: {ex.Message}");
+
+            throw;
+        }
+    }
+
+    public static void WriteToFile(string path, HistoryStorage data)
+    {
+        var jsonString = JsonPrettyFormatter.ToPrettyJson(data, AppJsonSerializerContext.Default.HistoryStorage);
+
+        try
+        {
+            File.WriteAllText(path, jsonString);
+        }
+        catch (Exception ex)
+        {
+            ExtensionHost.LogMessage($"[HistoryStorage] WriteFile failed: {ex.GetType().Name}: {ex.Message}");
+
+            throw;
+        }
+    }
+}

--- a/CmdPalWebSearchShortcut/WebSearchShortcut/JSONContext.cs
+++ b/CmdPalWebSearchShortcut/WebSearchShortcut/JSONContext.cs
@@ -1,10 +1,13 @@
 using System.Text.Json.Serialization;
+using WebSearchShortcut.History;
 
 namespace WebSearchShortcut;
 
 [JsonSourceGenerationOptions(IncludeFields = true)]
 [JsonSerializable(typeof(Storage))]
 [JsonSerializable(typeof(WebSearchShortcutDataEntry))]
+[JsonSerializable(typeof(HistoryStorage))]
+[JsonSerializable(typeof(HistoryEntry))]
 internal partial class AppJsonSerializerContext : JsonSerializerContext
 {
 }

--- a/CmdPalWebSearchShortcut/WebSearchShortcut/Pages/AddShortcutPage.cs
+++ b/CmdPalWebSearchShortcut/WebSearchShortcut/Pages/AddShortcutPage.cs
@@ -11,16 +11,14 @@ internal sealed partial class AddShortcutPage : ContentPage
 
     public AddShortcutPage(WebSearchShortcutDataEntry? shortcut)
     {
-        var name = shortcut?.Name ?? string.Empty;
-        var url = shortcut?.Url ?? string.Empty;
-        var isAdd = string.IsNullOrEmpty(name) && string.IsNullOrEmpty(url);
-
-        _addShortcutForm = new AddShortcutForm(shortcut);
+        bool isAdd = shortcut is null;
 
         Id = "WebSearchShortcut.AddShortcut";
-        Icon = IconHelpers.FromRelativePath("Assets\\SearchAdd.png");
-        Title = isAdd ? Resources.AddShortcut_AddTitle : Resources.SearchShortcut_EditTitle;
-        Name = isAdd ? Resources.AddShortcut_AddName : Resources.SearchShortcut_EditName;
+        Title = isAdd ? Resources.AddShortcutPage_Title_Add : Resources.AddShortcutPage_Title_Edit;
+        Name = $"[UNBOUND] {nameof(AddShortcutPage)}.{nameof(Name)} required - shortcut={(shortcut is null ? "null" : $"'{shortcut.Name}'")}";
+        Icon = isAdd ? IconHelpers.FromRelativePath("Assets\\SearchAdd.png") : Icons.Edit;
+
+        _addShortcutForm = new AddShortcutForm(shortcut);
     }
 
     internal event TypedEventHandler<object, WebSearchShortcutDataEntry>? AddedCommand

--- a/CmdPalWebSearchShortcut/WebSearchShortcut/Pages/AddShortcutPage.cs
+++ b/CmdPalWebSearchShortcut/WebSearchShortcut/Pages/AddShortcutPage.cs
@@ -16,7 +16,7 @@ internal sealed partial class AddShortcutPage : ContentPage
         Id = "WebSearchShortcut.AddShortcut";
         Title = isAdd ? Resources.AddShortcutPage_Title_Add : Resources.AddShortcutPage_Title_Edit;
         Name = $"[UNBOUND] {nameof(AddShortcutPage)}.{nameof(Name)} required - shortcut={(shortcut is null ? "null" : $"'{shortcut.Name}'")}";
-        Icon = isAdd ? IconHelpers.FromRelativePath("Assets\\SearchAdd.png") : Icons.Edit;
+        Icon = isAdd ? Icons.AddShortcut : Icons.EditShortcut;
 
         _addShortcutForm = new AddShortcutForm(shortcut);
     }

--- a/CmdPalWebSearchShortcut/WebSearchShortcut/Pages/SearchWebPage.cs
+++ b/CmdPalWebSearchShortcut/WebSearchShortcut/Pages/SearchWebPage.cs
@@ -14,9 +14,13 @@ namespace WebSearchShortcut;
 internal sealed partial class SearchWebPage : DynamicListPage
 {
     private readonly WebSearchShortcutDataEntry _shortcut;
-    private readonly IListItem _openHomePageItem;
+
+    private readonly IListItem _openHomepageListItem;
+    private readonly IContextItem _openHomepageContextItem;
+
     private IListItem[] _items = [];
     private IListItem[] _suggestionItems = [];
+
     private int _lastUpdateSearchTextEpoch;
     private readonly Lock _swapSuggestionsCancellationSourceLock = new();
     private readonly Lock _renderLock = new();
@@ -25,17 +29,29 @@ internal sealed partial class SearchWebPage : DynamicListPage
 
     public SearchWebPage(WebSearchShortcutDataEntry shortcut)
     {
+        Id = shortcut.Id;
+        Title = StringFormatter.Format(Resources.SearchWebPage_TitleTemplate, new() { ["shortcut"] = shortcut.Name });
+        Name = $"[UNBOUND] {nameof(SearchWebPage)}.{nameof(Name)} required - shortcut='{shortcut.Name}'";
+        Icon = IconService.GetIconInfo(shortcut);
+
         _shortcut = shortcut;
 
-        Id = shortcut.Id;
-        Name = shortcut.Name;
-        Icon = IconService.GetIconInfo(shortcut);
-        _openHomePageItem = new ListItem(new OpenHomePageCommand(shortcut))
+        var openHomepagecommand = new OpenHomePageCommand(shortcut)
         {
-            Title = StringFormatter.Format(Resources.OpenHomePage_TitleTemplate, new() { ["engine"] = Name })
+            Name = StringFormatter.Format(Resources.OpenHomepageItem_NameTemplate, new() { ["shortcut"] = shortcut.Name })
+        };
+        _openHomepageListItem = new ListItem(openHomepagecommand)
+        {
+            Title = StringFormatter.Format(Resources.OpenHomepageItem_TitleTemplate, new() { ["shortcut"] = shortcut.Name }),
+            Icon = Icons.Home
+        };
+        _openHomepageContextItem = new CommandContextItem(openHomepagecommand)
+        {
+            Title = StringFormatter.Format(Resources.OpenHomepageItem_TitleTemplate, new() { ["shortcut"] = shortcut.Name }),
+            Icon = Icons.Home
         };
 
-        _items = [_openHomePageItem];
+        _items = [_openHomepageListItem];
     }
 
     public override IListItem[] GetItems() => Volatile.Read(ref _items);
@@ -55,6 +71,7 @@ internal sealed partial class SearchWebPage : DynamicListPage
             if (currentEpoch != Volatile.Read(ref _lastUpdateSearchTextEpoch))
             {
                 currentCancellationSource?.Dispose();
+
                 return;
             }
 
@@ -73,7 +90,7 @@ internal sealed partial class SearchWebPage : DynamicListPage
         {
             UpdateSuggestionItems([], currentEpoch);
 
-            RenderItems([_openHomePageItem], currentEpoch);
+            RenderItems([_openHomepageListItem], currentEpoch);
 
             return;
         }
@@ -108,7 +125,8 @@ internal sealed partial class SearchWebPage : DynamicListPage
             currentCancellationSource!.Dispose();
         }
 
-        if (currentEpoch != Volatile.Read(ref _lastUpdateSearchTextEpoch)) return;
+        if (currentEpoch != Volatile.Read(ref _lastUpdateSearchTextEpoch))
+            return;
 
         UpdateSuggestionItems(suggestionItems, currentEpoch);
 
@@ -149,11 +167,17 @@ internal sealed partial class SearchWebPage : DynamicListPage
     {
         return
         [
-            new ListItem(new SearchWebCommand(_shortcut, searchText))
+            new ListItem(
+                new SearchWebCommand(_shortcut, searchText)
+                {
+                    Name = StringFormatter.Format(Resources.SearchQueryItem_NameTemplate, new() { ["shortcut"] = _shortcut.Name, ["query"] = searchText }),
+                }
+            )
             {
-                Title = searchText,
-                Subtitle = StringFormatter.Format(Resources.SearchQuery_SubtitleTemplate, new() { ["engine"] = Name, ["query"] = searchText }),
-                MoreCommands = [new CommandContextItem(new OpenHomePageCommand(_shortcut))]
+                Title = StringFormatter.Format(Resources.SearchQueryItem_TitleTemplate, new() { ["shortcut"] = _shortcut.Name, ["query"] = searchText }),
+                Subtitle = StringFormatter.Format(Resources.SearchQueryItem_SubtitleTemplate, new() { ["shortcut"] = _shortcut.Name, ["query"] = searchText }),
+                Icon = Icons.Search,
+                MoreCommands = [_openHomepageContextItem]
             }
         ];
     }
@@ -167,12 +191,18 @@ internal sealed partial class SearchWebPage : DynamicListPage
 
         return
         [
-            .. suggestions.Select(suggestion => new ListItem(new SearchWebCommand(_shortcut, suggestion.Title))
+            .. suggestions.Select(suggestion => new ListItem(
+                new SearchWebCommand(_shortcut, suggestion.Title)
+                {
+                    Name = StringFormatter.Format(Resources.SearchQueryItem_NameTemplate, new() { ["shortcut"] = _shortcut.Name, ["query"] =  suggestion.Title })
+                }
+            )
             {
-                Title = suggestion.Title,
-                Subtitle = suggestion.Description ?? StringFormatter.Format(Resources.SearchQuery_SubtitleTemplate, new() { ["engine"] = Name, ["query"] = suggestion.Title }),
+                Title = StringFormatter.Format(Resources.SearchQueryItem_TitleTemplate, new() { ["shortcut"] = _shortcut.Name, ["query"] =  suggestion.Title }),
+                Subtitle = suggestion.Description ?? StringFormatter.Format(Resources.SearchQueryItem_SubtitleTemplate, new() { ["shortcut"] = _shortcut.Name, ["query"] = suggestion.Title }),
+                Icon = Icons.Search,
                 TextToSuggest = suggestion.Title,
-                MoreCommands = [new CommandContextItem(new OpenHomePageCommand(_shortcut))]
+                MoreCommands = [_openHomepageContextItem]
             })
         ];
     }

--- a/CmdPalWebSearchShortcut/WebSearchShortcut/Pages/SearchWebPage.cs
+++ b/CmdPalWebSearchShortcut/WebSearchShortcut/Pages/SearchWebPage.cs
@@ -14,6 +14,7 @@ namespace WebSearchShortcut;
 
 internal sealed partial class SearchWebPage : DynamicListPage
 {
+    private const int MaxHistoryDisplayCount = 3;
     private const int MaxDisplayCount = 100;
 
     private readonly WebSearchShortcutDataEntry _shortcut;
@@ -98,11 +99,11 @@ internal sealed partial class SearchWebPage : DynamicListPage
         {
         }
 
+        var historyItems = BuildHistoryItems(newSearch);
+
         if (shouldOpenHomePage)
         {
             UpdateSuggestionItems([], currentEpoch);
-
-            var historyItems = BuildHistoryItems();
 
             RenderItems([_openHomepageListItem, .. historyItems], currentEpoch);
 
@@ -112,7 +113,7 @@ internal sealed partial class SearchWebPage : DynamicListPage
         var primaryItems = BuildPrimaryItems(newSearch);
         var snapshotSuggestions = Volatile.Read(ref _suggestionItems);
 
-        RenderItems([.. primaryItems, .. snapshotSuggestions], currentEpoch);
+        RenderItems([.. primaryItems, .. historyItems, .. snapshotSuggestions], currentEpoch);
 
         if (!shouldFetchSuggestions)
             return;
@@ -144,7 +145,7 @@ internal sealed partial class SearchWebPage : DynamicListPage
 
         UpdateSuggestionItems(suggestionItems, currentEpoch);
 
-        RenderItems([.. primaryItems, .. suggestionItems], currentEpoch);
+        RenderItems([.. primaryItems, .. historyItems, .. suggestionItems], currentEpoch);
     }
 
     private void RenderItems(IListItem[] items, int currentUpdateSearchTextEpoch)
@@ -197,11 +198,11 @@ internal sealed partial class SearchWebPage : DynamicListPage
         ];
     }
 
-    private ListItem[] BuildHistoryItems()
+    private ListItem[] BuildHistoryItems(string searchText)
     {
         var historyQueries = HistoryService
-            .Get(_shortcut.Name)
-            .Take(MaxDisplayCount - 1);
+            .Search(_shortcut.Name, searchText)
+            .Take(string.IsNullOrEmpty(searchText) ? MaxDisplayCount : MaxHistoryDisplayCount);
 
         return [
             .. historyQueries.Select(historyQuery => new ListItem(

--- a/CmdPalWebSearchShortcut/WebSearchShortcut/Pages/SearchWebPage.cs
+++ b/CmdPalWebSearchShortcut/WebSearchShortcut/Pages/SearchWebPage.cs
@@ -6,6 +6,7 @@ using Microsoft.CommandPalette.Extensions;
 using Microsoft.CommandPalette.Extensions.Toolkit;
 using WebSearchShortcut.Commands;
 using WebSearchShortcut.Helpers;
+using WebSearchShortcut.History;
 using WebSearchShortcut.Properties;
 using WebSearchShortcut.Services;
 
@@ -13,6 +14,8 @@ namespace WebSearchShortcut;
 
 internal sealed partial class SearchWebPage : DynamicListPage
 {
+    private const int MaxDisplayCount = 100;
+
     private readonly WebSearchShortcutDataEntry _shortcut;
 
     private readonly IListItem _openHomepageListItem;
@@ -50,11 +53,20 @@ internal sealed partial class SearchWebPage : DynamicListPage
             Title = StringFormatter.Format(Resources.OpenHomepageItem_TitleTemplate, new() { ["shortcut"] = shortcut.Name }),
             Icon = Icons.Home
         };
-
-        _items = [_openHomepageListItem];
     }
 
-    public override IListItem[] GetItems() => Volatile.Read(ref _items);
+    public override IListItem[] GetItems()
+    {
+        if (_items.Length == 0)
+            Rebuild();
+
+        return Volatile.Read(ref _items);
+    }
+
+    public void Rebuild()
+    {
+        UpdateSearchText(SearchText, SearchText);
+    }
 
     public override async void UpdateSearchText(string oldSearch, string newSearch)
     {
@@ -90,7 +102,9 @@ internal sealed partial class SearchWebPage : DynamicListPage
         {
             UpdateSuggestionItems([], currentEpoch);
 
-            RenderItems([_openHomepageListItem], currentEpoch);
+            var historyItems = BuildHistoryItems();
+
+            RenderItems([_openHomepageListItem, .. historyItems], currentEpoch);
 
             return;
         }
@@ -179,6 +193,29 @@ internal sealed partial class SearchWebPage : DynamicListPage
                 Icon = Icons.Search,
                 MoreCommands = [_openHomepageContextItem]
             }
+        ];
+    }
+
+    private ListItem[] BuildHistoryItems()
+    {
+        var historyQueries = HistoryService
+            .Get(_shortcut.Name)
+            .Take(MaxDisplayCount - 1);
+
+        return [
+            .. historyQueries.Select(historyQuery => new ListItem(
+                new SearchWebCommand(_shortcut, historyQuery)
+                {
+                    Name = StringFormatter.Format(Resources.SearchQueryItem_NameTemplate, new() { ["shortcut"] = _shortcut.Name, ["query"] = historyQuery }),
+                }
+            )
+            {
+                Title = StringFormatter.Format(Resources.SearchQueryItem_TitleTemplate, new() { ["shortcut"] = _shortcut.Name, ["query"] = historyQuery }),
+                Subtitle = StringFormatter.Format(Resources.SearchQueryItem_SubtitleTemplate, new() { ["shortcut"] = _shortcut.Name, ["query"] = historyQuery }),
+                Icon = Icons.History,
+                TextToSuggest = historyQuery,
+                MoreCommands = [_openHomepageContextItem]
+            })
         ];
     }
 

--- a/CmdPalWebSearchShortcut/WebSearchShortcut/Pages/SearchWebPage.cs
+++ b/CmdPalWebSearchShortcut/WebSearchShortcut/Pages/SearchWebPage.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -19,11 +20,11 @@ internal sealed partial class SearchWebPage : DynamicListPage
 
     private readonly WebSearchShortcutDataEntry _shortcut;
 
-    private readonly IListItem _openHomepageListItem;
-    private readonly IContextItem _openHomepageContextItem;
+    private readonly ListItem _openHomepageListItem;
+    private readonly CommandContextItem _openHomepageContextItem;
 
+    private ListItem[] _suggestionItems = [];
     private IListItem[] _items = [];
-    private IListItem[] _suggestionItems = [];
 
     private int _lastUpdateSearchTextEpoch;
     private readonly Lock _swapSuggestionsCancellationSourceLock = new();
@@ -113,12 +114,12 @@ internal sealed partial class SearchWebPage : DynamicListPage
         var primaryItems = BuildPrimaryItems(newSearch);
         var snapshotSuggestions = Volatile.Read(ref _suggestionItems);
 
-        RenderItems([.. primaryItems, .. historyItems, .. snapshotSuggestions], currentEpoch);
+        RenderItems(ItemIntegrate(primaryItems, historyItems, snapshotSuggestions), currentEpoch);
 
         if (!shouldFetchSuggestions)
             return;
 
-        IListItem[] suggestionItems;
+        ListItem[] suggestionItems;
         try
         {
             suggestionItems = await FetchSuggestionItemsAsync(newSearch, currentCancellationSource!.Token).ConfigureAwait(false);
@@ -145,7 +146,69 @@ internal sealed partial class SearchWebPage : DynamicListPage
 
         UpdateSuggestionItems(suggestionItems, currentEpoch);
 
-        RenderItems([.. primaryItems, .. historyItems, .. suggestionItems], currentEpoch);
+        RenderItems(ItemIntegrate(primaryItems, historyItems, suggestionItems), currentEpoch);
+    }
+
+    private static IListItem[] ItemIntegrate(ListItem[] primaryItems, ListItem[] historyItems, ListItem[] suggestionItems)
+    {
+        var primaryItemByTitle = primaryItems.ToDictionary(item => item.Title, item => item);
+        var historyItemByTitle = historyItems.ToDictionary(item => item.Title, item => item);
+        var suggestionItemByTitle = suggestionItems.ToDictionary(item => item.Title, item => item);
+
+        HashSet<string> removeFromHistory = [];
+        HashSet<string> removeFromSuggestions = [];
+
+        foreach (var (title, primaryItem) in primaryItemByTitle)
+        {
+            if (historyItemByTitle.TryGetValue(title, out var historyItem))
+            {
+                primaryItem.Icon = Icons.History;
+                primaryItem.MoreCommands = historyItem.MoreCommands;
+
+                if (suggestionItemByTitle.TryGetValue(title, out var suggestionItem))
+                {
+                    historyItem.Subtitle = suggestionItem.Subtitle;
+                    removeFromSuggestions.Add(title);
+                }
+                else
+                {
+                    removeFromHistory.Add(title);
+                }
+            }
+        }
+
+        foreach (var (title, historyItem) in historyItemByTitle)
+        {
+            if (removeFromHistory.Contains(title))
+                continue;
+
+            if (removeFromSuggestions.Contains(title))
+                continue;
+
+            if (suggestionItemByTitle.TryGetValue(title, out var suggestionItem))
+            {
+                historyItem.Subtitle = suggestionItem.Subtitle;
+                removeFromSuggestions.Add(title);
+            }
+        }
+
+        List<IListItem> items = new(primaryItems.Length + historyItems.Length + suggestionItems.Length);
+
+        items.AddRange(primaryItems);
+
+        foreach (var historyItem in historyItems)
+        {
+            if (!removeFromHistory.Contains(historyItem.Title))
+                items.Add(historyItem);
+        }
+
+        foreach (var suggestoinItem in suggestionItems)
+        {
+            if (!removeFromSuggestions.Contains(suggestoinItem.Title))
+                items.Add(suggestoinItem);
+        }
+
+        return [.. items.Take(MaxDisplayCount)];
     }
 
     private void RenderItems(IListItem[] items, int currentUpdateSearchTextEpoch)
@@ -164,7 +227,7 @@ internal sealed partial class SearchWebPage : DynamicListPage
         RaiseItemsChanged(items.Length);
     }
 
-    private void UpdateSuggestionItems(IListItem[] suggestionItems, int currentUpdateSearchTextEpoch)
+    private void UpdateSuggestionItems(ListItem[] suggestionItems, int currentUpdateSearchTextEpoch)
     {
         if (currentUpdateSearchTextEpoch != Volatile.Read(ref _lastUpdateSearchTextEpoch))
             return;

--- a/CmdPalWebSearchShortcut/WebSearchShortcut/Pages/SearchWebPage.cs
+++ b/CmdPalWebSearchShortcut/WebSearchShortcut/Pages/SearchWebPage.cs
@@ -184,7 +184,8 @@ internal sealed partial class SearchWebPage : DynamicListPage
             new ListItem(
                 new SearchWebCommand(_shortcut, searchText)
                 {
-                    Name = StringFormatter.Format(Resources.SearchQueryItem_NameTemplate, new() { ["shortcut"] = _shortcut.Name, ["query"] = searchText }),
+                    Icon = Icons.Search,
+                    Name = StringFormatter.Format(Resources.SearchQueryItem_NameTemplate, new() { ["shortcut"] = _shortcut.Name, ["query"] = searchText })
                 }
             )
             {
@@ -206,7 +207,8 @@ internal sealed partial class SearchWebPage : DynamicListPage
             .. historyQueries.Select(historyQuery => new ListItem(
                 new SearchWebCommand(_shortcut, historyQuery)
                 {
-                    Name = StringFormatter.Format(Resources.SearchQueryItem_NameTemplate, new() { ["shortcut"] = _shortcut.Name, ["query"] = historyQuery }),
+                    Icon = Icons.Search,
+                    Name = StringFormatter.Format(Resources.SearchQueryItem_NameTemplate, new() { ["shortcut"] = _shortcut.Name, ["query"] = historyQuery })
                 }
             )
             {
@@ -214,7 +216,23 @@ internal sealed partial class SearchWebPage : DynamicListPage
                 Subtitle = StringFormatter.Format(Resources.SearchQueryItem_SubtitleTemplate, new() { ["shortcut"] = _shortcut.Name, ["query"] = historyQuery }),
                 Icon = Icons.History,
                 TextToSuggest = historyQuery,
-                MoreCommands = [_openHomepageContextItem]
+                MoreCommands = [
+                    _openHomepageContextItem,
+                    new CommandContextItem(
+                        title: StringFormatter.Format(Resources.DeleteHistory_TitleTemplate, new() { ["shortcut"] = _shortcut.Name, ["query"] = historyQuery }),
+                        name: $"[UNREACHABLE] DeleteHistory.Name - shortcut='{_shortcut.Name}', query='{historyQuery}'",
+                        action: () =>
+                        {
+                            HistoryService.Remove(_shortcut.Name, historyQuery);
+                            Rebuild();
+                        },
+                        result: CommandResult.KeepOpen()
+                    )
+                    {
+                        Icon = Icons.DeleteHistory,
+                        IsCritical = true
+                    }
+                ]
             })
         ];
     }
@@ -231,6 +249,7 @@ internal sealed partial class SearchWebPage : DynamicListPage
             .. suggestions.Select(suggestion => new ListItem(
                 new SearchWebCommand(_shortcut, suggestion.Title)
                 {
+                    Icon = Icons.Search,
                     Name = StringFormatter.Format(Resources.SearchQueryItem_NameTemplate, new() { ["shortcut"] = _shortcut.Name, ["query"] =  suggestion.Title })
                 }
             )

--- a/CmdPalWebSearchShortcut/WebSearchShortcut/Pages/SearchWebPage.cs
+++ b/CmdPalWebSearchShortcut/WebSearchShortcut/Pages/SearchWebPage.cs
@@ -15,9 +15,6 @@ namespace WebSearchShortcut;
 
 internal sealed partial class SearchWebPage : DynamicListPage
 {
-    private const int MaxHistoryDisplayCount = 3;
-    private const int MaxDisplayCount = 100;
-
     private readonly WebSearchShortcutDataEntry _shortcut;
 
     private readonly ListItem _openHomepageListItem;
@@ -26,13 +23,15 @@ internal sealed partial class SearchWebPage : DynamicListPage
     private ListItem[] _suggestionItems = [];
     private IListItem[] _items = [];
 
+    private readonly SettingsManager _settingsManager;
+
     private int _lastUpdateSearchTextEpoch;
     private readonly Lock _swapSuggestionsCancellationSourceLock = new();
     private readonly Lock _renderLock = new();
     private readonly Lock _updateSuggestionLock = new();
     private CancellationTokenSource? _previousSuggestionsCancellationSource;
 
-    public SearchWebPage(WebSearchShortcutDataEntry shortcut)
+    public SearchWebPage(WebSearchShortcutDataEntry shortcut, SettingsManager settingsManager)
     {
         Id = shortcut.Id;
         Title = StringFormatter.Format(Resources.SearchWebPage_TitleTemplate, new() { ["shortcut"] = shortcut.Name });
@@ -55,6 +54,10 @@ internal sealed partial class SearchWebPage : DynamicListPage
             Title = StringFormatter.Format(Resources.OpenHomepageItem_TitleTemplate, new() { ["shortcut"] = shortcut.Name }),
             Icon = Icons.Home
         };
+
+        _settingsManager = settingsManager;
+
+        _settingsManager.SettingsChanged += (s, a) => Rebuild();
     }
 
     public override IListItem[] GetItems()
@@ -149,7 +152,7 @@ internal sealed partial class SearchWebPage : DynamicListPage
         RenderItems(ItemIntegrate(primaryItems, historyItems, suggestionItems), currentEpoch);
     }
 
-    private static IListItem[] ItemIntegrate(ListItem[] primaryItems, ListItem[] historyItems, ListItem[] suggestionItems)
+    private IListItem[] ItemIntegrate(ListItem[] primaryItems, ListItem[] historyItems, ListItem[] suggestionItems)
     {
         var primaryItemByTitle = primaryItems.ToDictionary(item => item.Title, item => item);
         var historyItemByTitle = historyItems.ToDictionary(item => item.Title, item => item);
@@ -208,7 +211,7 @@ internal sealed partial class SearchWebPage : DynamicListPage
                 items.Add(suggestoinItem);
         }
 
-        return [.. items.Take(MaxDisplayCount)];
+        return [.. items.Take(_settingsManager.MaxDisplayCount)];
     }
 
     private void RenderItems(IListItem[] items, int currentUpdateSearchTextEpoch)
@@ -265,7 +268,7 @@ internal sealed partial class SearchWebPage : DynamicListPage
     {
         var historyQueries = HistoryService
             .Search(_shortcut.Name, searchText)
-            .Take(string.IsNullOrEmpty(searchText) ? MaxDisplayCount : MaxHistoryDisplayCount);
+            .Take(string.IsNullOrEmpty(searchText) ? _settingsManager.MaxDisplayCount : _settingsManager.MaxHistoryDisplayCount);
 
         return [
             .. historyQueries.Select(historyQuery => new ListItem(

--- a/CmdPalWebSearchShortcut/WebSearchShortcut/Properties/Icons.cs
+++ b/CmdPalWebSearchShortcut/WebSearchShortcut/Properties/Icons.cs
@@ -9,8 +9,13 @@ namespace WebSearchShortcut.Properties;
 /// <summary>
 /// Provides commonly used icons for the WebSearchShortcut application
 /// </summary>
-public static class Icons
+internal static class Icons
 {
+    /// <summary>
+    /// Default fallback icon for links
+    /// </summary>
+    public static IconInfo Link { get; } = new("🔗");
+
     /// <summary>
     /// Edit icon (pencil)
     /// </summary>
@@ -22,9 +27,9 @@ public static class Icons
     public static IconInfo Delete { get; } = new("\uE74D");
 
     /// <summary>
-    /// Default fallback icon for links
+    /// Homepage icon
     /// </summary>
-    public static IconInfo Link { get; } = new("🔗");
+    public static IconInfo Home { get; } = new("\uE80F");
 
     /// <summary>
     /// Search icon

--- a/CmdPalWebSearchShortcut/WebSearchShortcut/Properties/Icons.cs
+++ b/CmdPalWebSearchShortcut/WebSearchShortcut/Properties/Icons.cs
@@ -55,4 +55,9 @@ internal static class Icons
     /// History icon 
     /// </summary>
     public static IconInfo History { get; } = new("\uE81C");
+
+    /// <summary>
+    /// Delete History icon
+    /// </summary>
+    public static readonly IconInfo DeleteHistory = new("\uE894");
 }

--- a/CmdPalWebSearchShortcut/WebSearchShortcut/Properties/Icons.cs
+++ b/CmdPalWebSearchShortcut/WebSearchShortcut/Properties/Icons.cs
@@ -12,6 +12,21 @@ namespace WebSearchShortcut.Properties;
 internal static class Icons
 {
     /// <summary>
+    /// Extension logo icon
+    /// </summary>
+    public static IconInfo Logo { get; } = IconHelpers.FromRelativePath("Assets\\Search.png");
+
+    /// <summary>
+    /// "Add Shortcut" icon
+    /// </summary>
+    public static IconInfo AddShortcut { get; } = IconHelpers.FromRelativePath("Assets\\SearchAdd.png");
+
+    /// <summary>
+    /// "Edit Shortcut" icon
+    /// </summary>
+    public static IconInfo EditShortcut { get; } = new("\uE70F");
+
+    /// <summary>
     /// Default fallback icon for links
     /// </summary>
     public static IconInfo Link { get; } = new("🔗");

--- a/CmdPalWebSearchShortcut/WebSearchShortcut/Properties/Icons.cs
+++ b/CmdPalWebSearchShortcut/WebSearchShortcut/Properties/Icons.cs
@@ -50,4 +50,9 @@ internal static class Icons
     /// Search icon
     /// </summary>
     public static IconInfo Search { get; } = new("\uE721");
+
+    /// <summary> 
+    /// History icon 
+    /// </summary>
+    public static IconInfo History { get; } = new("\uE81C");
 }

--- a/CmdPalWebSearchShortcut/WebSearchShortcut/Properties/Resources.Designer.cs
+++ b/CmdPalWebSearchShortcut/WebSearchShortcut/Properties/Resources.Designer.cs
@@ -61,110 +61,92 @@ namespace WebSearchShortcut.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Add Search Shortcut.
-        /// </summary>
-        internal static string AddShortcut_AddName {
-            get {
-                return ResourceManager.GetString("AddShortcut_AddName", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Add Search Shortcut.
-        /// </summary>
-        internal static string AddShortcut_AddTitle {
-            get {
-                return ResourceManager.GetString("AddShortcut_AddTitle", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Browser Arguments (Optional).
         /// </summary>
-        internal static string AddShortcutForm_BrowserArgsLabel {
+        internal static string AddShortcutForm_BrowserArgs_Label {
             get {
-                return ResourceManager.GetString("AddShortcutForm_BrowserArgsLabel", resourceCulture);
+                return ResourceManager.GetString("AddShortcutForm_BrowserArgs_Label", resourceCulture);
             }
         }
         
         /// <summary>
         ///   Looks up a localized string similar to Browser launch arguments, use %1 for URL.
         /// </summary>
-        internal static string AddShortcutForm_BrowserArgsPlaceholder {
+        internal static string AddShortcutForm_BrowserArgs_Placeholder {
             get {
-                return ResourceManager.GetString("AddShortcutForm_BrowserArgsPlaceholder", resourceCulture);
+                return ResourceManager.GetString("AddShortcutForm_BrowserArgs_Placeholder", resourceCulture);
             }
         }
         
         /// <summary>
         ///   Looks up a localized string similar to Default.
         /// </summary>
-        internal static string AddShortcutForm_BrowserPathDefault {
+        internal static string AddShortcutForm_BrowserPath_Default {
             get {
-                return ResourceManager.GetString("AddShortcutForm_BrowserPathDefault", resourceCulture);
+                return ResourceManager.GetString("AddShortcutForm_BrowserPath_Default", resourceCulture);
             }
         }
         
         /// <summary>
         ///   Looks up a localized string similar to Browser.
         /// </summary>
-        internal static string AddShortcutForm_BrowserPathLabel {
+        internal static string AddShortcutForm_BrowserPath_Label {
             get {
-                return ResourceManager.GetString("AddShortcutForm_BrowserPathLabel", resourceCulture);
+                return ResourceManager.GetString("AddShortcutForm_BrowserPath_Label", resourceCulture);
             }
         }
         
         /// <summary>
         ///   Looks up a localized string similar to Custom Home Page (Optional).
         /// </summary>
-        internal static string AddShortcutForm_HomepageLabel {
+        internal static string AddShortcutForm_Homepage_Label {
             get {
-                return ResourceManager.GetString("AddShortcutForm_HomepageLabel", resourceCulture);
+                return ResourceManager.GetString("AddShortcutForm_Homepage_Label", resourceCulture);
             }
         }
         
         /// <summary>
         ///   Looks up a localized string similar to Use domain by default.
         /// </summary>
-        internal static string AddShortcutForm_HomepagePlaceholder {
+        internal static string AddShortcutForm_Homepage_Placeholder {
             get {
-                return ResourceManager.GetString("AddShortcutForm_HomepagePlaceholder", resourceCulture);
+                return ResourceManager.GetString("AddShortcutForm_Homepage_Placeholder", resourceCulture);
             }
         }
         
         /// <summary>
         ///   Looks up a localized string similar to Name is required.
         /// </summary>
-        internal static string AddShortcutForm_NameErrorMessage {
+        internal static string AddShortcutForm_Name_ErrorMessage {
             get {
-                return ResourceManager.GetString("AddShortcutForm_NameErrorMessage", resourceCulture);
+                return ResourceManager.GetString("AddShortcutForm_Name_ErrorMessage", resourceCulture);
             }
         }
         
         /// <summary>
         ///   Looks up a localized string similar to Name.
         /// </summary>
-        internal static string AddShortcutForm_NameLabel {
+        internal static string AddShortcutForm_Name_Label {
             get {
-                return ResourceManager.GetString("AddShortcutForm_NameLabel", resourceCulture);
+                return ResourceManager.GetString("AddShortcutForm_Name_Label", resourceCulture);
             }
         }
         
         /// <summary>
         ///   Looks up a localized string similar to Replace Whitespace (Optional).
         /// </summary>
-        internal static string AddShortcutForm_ReplaceWhitespaceLabel {
+        internal static string AddShortcutForm_ReplaceWhitespace_Label {
             get {
-                return ResourceManager.GetString("AddShortcutForm_ReplaceWhitespaceLabel", resourceCulture);
+                return ResourceManager.GetString("AddShortcutForm_ReplaceWhitespace_Label", resourceCulture);
             }
         }
         
         /// <summary>
         ///   Looks up a localized string similar to Specify which character(s) to replace a space.
         /// </summary>
-        internal static string AddShortcutForm_ReplaceWhitespacePlaceholder {
+        internal static string AddShortcutForm_ReplaceWhitespace_Placeholder {
             get {
-                return ResourceManager.GetString("AddShortcutForm_ReplaceWhitespacePlaceholder", resourceCulture);
+                return ResourceManager.GetString("AddShortcutForm_ReplaceWhitespace_Placeholder", resourceCulture);
             }
         }
         
@@ -180,135 +162,198 @@ namespace WebSearchShortcut.Properties {
         /// <summary>
         ///   Looks up a localized string similar to Suggestion Provider.
         /// </summary>
-        internal static string AddShortcutForm_SuggestionProviderLabel {
+        internal static string AddShortcutForm_SuggestionProvider_Label {
             get {
-                return ResourceManager.GetString("AddShortcutForm_SuggestionProviderLabel", resourceCulture);
+                return ResourceManager.GetString("AddShortcutForm_SuggestionProvider_Label", resourceCulture);
             }
         }
         
         /// <summary>
         ///   Looks up a localized string similar to None.
         /// </summary>
-        internal static string AddShortcutForm_SuggestionProviderNone {
+        internal static string AddShortcutForm_SuggestionProvider_None {
             get {
-                return ResourceManager.GetString("AddShortcutForm_SuggestionProviderNone", resourceCulture);
+                return ResourceManager.GetString("AddShortcutForm_SuggestionProvider_None", resourceCulture);
             }
         }
         
         /// <summary>
         ///   Looks up a localized string similar to Invalid Suggestion Provider.
         /// </summary>
-        internal static string AddShortcutForm_SuggestionProviderPlaceholder {
+        internal static string AddShortcutForm_SuggestionProvider_Placeholder {
             get {
-                return ResourceManager.GetString("AddShortcutForm_SuggestionProviderPlaceholder", resourceCulture);
+                return ResourceManager.GetString("AddShortcutForm_SuggestionProvider_Placeholder", resourceCulture);
             }
         }
         
         /// <summary>
         ///   Looks up a localized string similar to URL is required.
         /// </summary>
-        internal static string AddShortcutForm_UrlErrorMessage {
+        internal static string AddShortcutForm_Url_ErrorMessage {
             get {
-                return ResourceManager.GetString("AddShortcutForm_UrlErrorMessage", resourceCulture);
+                return ResourceManager.GetString("AddShortcutForm_Url_ErrorMessage", resourceCulture);
             }
         }
         
         /// <summary>
         ///   Looks up a localized string similar to URL.
         /// </summary>
-        internal static string AddShortcutForm_UrlLabel {
+        internal static string AddShortcutForm_Url_Label {
             get {
-                return ResourceManager.GetString("AddShortcutForm_UrlLabel", resourceCulture);
+                return ResourceManager.GetString("AddShortcutForm_Url_Label", resourceCulture);
             }
         }
         
         /// <summary>
         ///   Looks up a localized string similar to Use %s in the URL for the search term.
         /// </summary>
-        internal static string AddShortcutForm_UrlPlaceholder {
+        internal static string AddShortcutForm_Url_Placeholder {
             get {
-                return ResourceManager.GetString("AddShortcutForm_UrlPlaceholder", resourceCulture);
+                return ResourceManager.GetString("AddShortcutForm_Url_Placeholder", resourceCulture);
             }
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Open {engine}.
+        ///   Looks up a localized string similar to Add Search Shortcut.
         /// </summary>
-        internal static string OpenHomePage_NameTemplate {
+        internal static string AddShortcutItem_Name {
             get {
-                return ResourceManager.GetString("OpenHomePage_NameTemplate", resourceCulture);
+                return ResourceManager.GetString("AddShortcutItem_Name", resourceCulture);
             }
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Open {engine}.
+        ///   Looks up a localized string similar to Add Search Shortcut.
         /// </summary>
-        internal static string OpenHomePage_TitleTemplate {
+        internal static string AddShortcutItem_Title {
             get {
-                return ResourceManager.GetString("OpenHomePage_TitleTemplate", resourceCulture);
+                return ResourceManager.GetString("AddShortcutItem_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Add Search Shortcut.
+        /// </summary>
+        internal static string AddShortcutPage_Title_Add {
+            get {
+                return ResourceManager.GetString("AddShortcutPage_Title_Add", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Edit Search Shortcut.
+        /// </summary>
+        internal static string AddShortcutPage_Title_Edit {
+            get {
+                return ResourceManager.GetString("AddShortcutPage_Title_Edit", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Delete.
+        /// </summary>
+        internal static string DeleteShortcutItem_TitleTemplate {
+            get {
+                return ResourceManager.GetString("DeleteShortcutItem_TitleTemplate", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Edit Search Shortcut.
+        /// </summary>
+        internal static string EditShortcutItem_NameTemplate {
+            get {
+                return ResourceManager.GetString("EditShortcutItem_NameTemplate", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Edit Search Shortcut.
+        /// </summary>
+        internal static string EditShortcutItem_TitleTemplate {
+            get {
+                return ResourceManager.GetString("EditShortcutItem_TitleTemplate", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Open {shortcut}.
+        /// </summary>
+        internal static string OpenHomepageItem_NameTemplate {
+            get {
+                return ResourceManager.GetString("OpenHomepageItem_NameTemplate", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Open {shortcut}.
+        /// </summary>
+        internal static string OpenHomepageItem_TitleTemplate {
+            get {
+                return ResourceManager.GetString("OpenHomepageItem_TitleTemplate", resourceCulture);
             }
         }
         
         /// <summary>
         ///   Looks up a localized string similar to Search for &quot;{query}&quot;.
         /// </summary>
-        internal static string SearchQuery_NameTemplate {
+        internal static string SearchQueryItem_NameTemplate {
             get {
-                return ResourceManager.GetString("SearchQuery_NameTemplate", resourceCulture);
+                return ResourceManager.GetString("SearchQueryItem_NameTemplate", resourceCulture);
             }
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Search {engine} for &quot;{query}&quot;.
+        ///   Looks up a localized string similar to Search {shortcut} for &quot;{query}&quot;.
         /// </summary>
-        internal static string SearchQuery_SubtitleTemplate {
+        internal static string SearchQueryItem_SubtitleTemplate {
             get {
-                return ResourceManager.GetString("SearchQuery_SubtitleTemplate", resourceCulture);
+                return ResourceManager.GetString("SearchQueryItem_SubtitleTemplate", resourceCulture);
             }
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Delete.
+        ///   Looks up a localized string similar to {query}.
         /// </summary>
-        internal static string SearchShortcut_DeleteName {
+        internal static string SearchQueryItem_TitleTemplate {
             get {
-                return ResourceManager.GetString("SearchShortcut_DeleteName", resourceCulture);
+                return ResourceManager.GetString("SearchQueryItem_TitleTemplate", resourceCulture);
             }
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Delete.
+        ///   Looks up a localized string similar to {shortcut}.
         /// </summary>
-        internal static string SearchShortcut_DeleteTitle {
+        internal static string SearchWebPage_TitleTemplate {
             get {
-                return ResourceManager.GetString("SearchShortcut_DeleteTitle", resourceCulture);
+                return ResourceManager.GetString("SearchWebPage_TitleTemplate", resourceCulture);
             }
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Edit Search Shortcut.
+        ///   Looks up a localized string similar to {shortcut}.
         /// </summary>
-        internal static string SearchShortcut_EditName {
+        internal static string ShortcutItem_NameTemplate {
             get {
-                return ResourceManager.GetString("SearchShortcut_EditName", resourceCulture);
+                return ResourceManager.GetString("ShortcutItem_NameTemplate", resourceCulture);
             }
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Edit Search Shortcut.
+        ///   Looks up a localized string similar to Search {shortcut}.
         /// </summary>
-        internal static string SearchShortcut_EditTitle {
+        internal static string ShortcutItem_SubtitleTemplate {
             get {
-                return ResourceManager.GetString("SearchShortcut_EditTitle", resourceCulture);
+                return ResourceManager.GetString("ShortcutItem_SubtitleTemplate", resourceCulture);
             }
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Search {engine}.
+        ///   Looks up a localized string similar to {shortcut}.
         /// </summary>
-        internal static string SearchShortcut_SubtitleTemplate {
+        internal static string ShortcutItem_TitleTemplate {
             get {
-                return ResourceManager.GetString("SearchShortcut_SubtitleTemplate", resourceCulture);
+                return ResourceManager.GetString("ShortcutItem_TitleTemplate", resourceCulture);
             }
         }
         

--- a/CmdPalWebSearchShortcut/WebSearchShortcut/Properties/Resources.Designer.cs
+++ b/CmdPalWebSearchShortcut/WebSearchShortcut/Properties/Resources.Designer.cs
@@ -133,6 +133,24 @@ namespace WebSearchShortcut.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Search History.
+        /// </summary>
+        internal static string AddShortcutForm_RecordHistory_Label {
+            get {
+                return ResourceManager.GetString("AddShortcutForm_RecordHistory_Label", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Record history for this shortcut.
+        /// </summary>
+        internal static string AddShortcutForm_RecordHistory_Title {
+            get {
+                return ResourceManager.GetString("AddShortcutForm_RecordHistory_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Replace Whitespace (Optional).
         /// </summary>
         internal static string AddShortcutForm_ReplaceWhitespace_Label {
@@ -345,6 +363,60 @@ namespace WebSearchShortcut.Properties {
         internal static string SearchWebPage_TitleTemplate {
             get {
                 return ResourceManager.GetString("SearchWebPage_TitleTemplate", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Maximum total items shown per search.
+        /// </summary>
+        internal static string Settings_MaxDisplayCount_Description {
+            get {
+                return ResourceManager.GetString("Settings_MaxDisplayCount_Description", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Must be an integer greater than or equal to 1.
+        /// </summary>
+        internal static string Settings_MaxDisplayCount_ErrorMessage {
+            get {
+                return ResourceManager.GetString("Settings_MaxDisplayCount_ErrorMessage", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Max Search Results.
+        /// </summary>
+        internal static string Settings_MaxDisplayCount_Label {
+            get {
+                return ResourceManager.GetString("Settings_MaxDisplayCount_Label", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Maximum number of history results shown during search; set to 0 to hide history. Any value exceeding “Max Search Results” is ignored..
+        /// </summary>
+        internal static string Settings_MaxHistoryDisplayCount_Description {
+            get {
+                return ResourceManager.GetString("Settings_MaxHistoryDisplayCount_Description", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Must be an integer greater than or equal to 0.
+        /// </summary>
+        internal static string Settings_MaxHistoryDisplayCount_ErrorMessage {
+            get {
+                return ResourceManager.GetString("Settings_MaxHistoryDisplayCount_ErrorMessage", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Max History Results.
+        /// </summary>
+        internal static string Settings_MaxHistoryDisplayCount_Label {
+            get {
+                return ResourceManager.GetString("Settings_MaxHistoryDisplayCount_Label", resourceCulture);
             }
         }
         

--- a/CmdPalWebSearchShortcut/WebSearchShortcut/Properties/Resources.Designer.cs
+++ b/CmdPalWebSearchShortcut/WebSearchShortcut/Properties/Resources.Designer.cs
@@ -250,6 +250,24 @@ namespace WebSearchShortcut.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Clear {shortcut}&apos;s History.
+        /// </summary>
+        internal static string ClearHistory_TitleTemplate {
+            get {
+                return ResourceManager.GetString("ClearHistory_TitleTemplate", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Delete.
+        /// </summary>
+        internal static string DeleteHistory_TitleTemplate {
+            get {
+                return ResourceManager.GetString("DeleteHistory_TitleTemplate", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Delete.
         /// </summary>
         internal static string DeleteShortcutItem_TitleTemplate {

--- a/CmdPalWebSearchShortcut/WebSearchShortcut/Properties/Resources.fr.resx
+++ b/CmdPalWebSearchShortcut/WebSearchShortcut/Properties/Resources.fr.resx
@@ -192,6 +192,9 @@
   <data name="ShortcutItem_NameTemplate" xml:space="preserve">
     <value>{shortcut}</value>
   </data>
+  <data name="ClearHistory_TitleTemplate" xml:space="preserve">
+    <value />
+  </data>
   <data name="EditShortcutItem_TitleTemplate" xml:space="preserve">
     <value>Modifier le raccourci de recherche</value>
   </data>
@@ -218,5 +221,8 @@
   </data>
   <data name="SearchQueryItem_NameTemplate" xml:space="preserve">
     <value>Rechercher "{query}"</value>
+  </data>
+  <data name="DeleteHistory_TitleTemplate" xml:space="preserve">
+    <value />
   </data>
 </root>

--- a/CmdPalWebSearchShortcut/WebSearchShortcut/Properties/Resources.fr.resx
+++ b/CmdPalWebSearchShortcut/WebSearchShortcut/Properties/Resources.fr.resx
@@ -156,6 +156,12 @@
   <data name="AddShortcutForm_SuggestionProvider_None" xml:space="preserve">
     <value>Aucun</value>
   </data>
+  <data name="AddShortcutForm_RecordHistory_Label" xml:space="preserve">
+    <value />
+  </data>
+  <data name="AddShortcutForm_RecordHistory_Title" xml:space="preserve">
+    <value />
+  </data>
   <data name="AddShortcutForm_Homepage_Label" xml:space="preserve">
     <value>Page d'accueil personnalisée (Optionnel)</value>
   </data>
@@ -223,6 +229,24 @@
     <value>Rechercher "{query}"</value>
   </data>
   <data name="DeleteHistory_TitleTemplate" xml:space="preserve">
+    <value />
+  </data>
+  <data name="Settings_MaxDisplayCount_Label" xml:space="preserve">
+    <value />
+  </data>
+  <data name="Settings_MaxDisplayCount_Description" xml:space="preserve">
+    <value />
+  </data>
+  <data name="Settings_MaxDisplayCount_ErrorMessage" xml:space="preserve">
+    <value />
+  </data>
+  <data name="Settings_MaxHistoryDisplayCount_Label" xml:space="preserve">
+    <value />
+  </data>
+  <data name="Settings_MaxHistoryDisplayCount_Description" xml:space="preserve">
+    <value />
+  </data>
+  <data name="Settings_MaxHistoryDisplayCount_ErrorMessage" xml:space="preserve">
     <value />
   </data>
 </root>

--- a/CmdPalWebSearchShortcut/WebSearchShortcut/Properties/Resources.fr.resx
+++ b/CmdPalWebSearchShortcut/WebSearchShortcut/Properties/Resources.fr.resx
@@ -120,88 +120,103 @@
   <data name="WebSearchShortcut_DisplayName" xml:space="preserve">
     <value>WebSearchShortcut</value>
   </data>
-  <data name="AddShortcut_AddName" xml:space="preserve">
+  <data name="AddShortcutItem_Title" xml:space="preserve">
     <value>Ajouter un raccourci de recherche</value>
   </data>
-  <data name="AddShortcut_AddTitle" xml:space="preserve">
+  <data name="AddShortcutItem_Name" xml:space="preserve">
     <value>Ajouter un raccourci de recherche</value>
   </data>
-  <data name="AddShortcutForm_NameLabel" xml:space="preserve">
+  <data name="AddShortcutPage_Title_Add" xml:space="preserve">
+    <value>Ajouter un raccourci de recherche</value>
+  </data>
+  <data name="AddShortcutPage_Title_Edit" xml:space="preserve">
+    <value>Modifier le raccourci de recherche</value>
+  </data>
+  <data name="AddShortcutForm_Name_Label" xml:space="preserve">
     <value>Nom</value>
   </data>
-  <data name="AddShortcutForm_NameErrorMessage" xml:space="preserve">
+  <data name="AddShortcutForm_Name_ErrorMessage" xml:space="preserve">
     <value>Le nom est obligatoire</value>
   </data>
-  <data name="AddShortcutForm_UrlLabel" xml:space="preserve">
+  <data name="AddShortcutForm_Url_Label" xml:space="preserve">
     <value>URL</value>
   </data>
-  <data name="AddShortcutForm_UrlPlaceholder" xml:space="preserve">
+  <data name="AddShortcutForm_Url_Placeholder" xml:space="preserve">
     <value>Utilisez %s dans l'URL pour le terme de recherche</value>
   </data>
-  <data name="AddShortcutForm_UrlErrorMessage" xml:space="preserve">
+  <data name="AddShortcutForm_Url_ErrorMessage" xml:space="preserve">
     <value>L'URL est obligatoire</value>
   </data>
-  <data name="AddShortcutForm_SuggestionProviderLabel" xml:space="preserve">
+  <data name="AddShortcutForm_SuggestionProvider_Label" xml:space="preserve">
     <value>Fournisseur de suggestions</value>
   </data>
-  <data name="AddShortcutForm_SuggestionProviderPlaceholder" xml:space="preserve">
+  <data name="AddShortcutForm_SuggestionProvider_Placeholder" xml:space="preserve">
     <value>Fournisseur de suggestions invalide</value>
   </data>
-  <data name="AddShortcutForm_SuggestionProviderNone" xml:space="preserve">
+  <data name="AddShortcutForm_SuggestionProvider_None" xml:space="preserve">
     <value>Aucun</value>
   </data>
-  <data name="AddShortcutForm_ReplaceWhitespaceLabel" xml:space="preserve">
-    <value>Remplacer les espaces (Optionnel)</value>
-  </data>
-  <data name="AddShortcutForm_ReplaceWhitespacePlaceholder" xml:space="preserve">
-    <value>Spécifiez quel(s) caractère(s) remplace(nt) un espace</value>
-  </data>
-  <data name="AddShortcutForm_HomepageLabel" xml:space="preserve">
+  <data name="AddShortcutForm_Homepage_Label" xml:space="preserve">
     <value>Page d'accueil personnalisée (Optionnel)</value>
   </data>
-  <data name="AddShortcutForm_HomepagePlaceholder" xml:space="preserve">
+  <data name="AddShortcutForm_Homepage_Placeholder" xml:space="preserve">
     <value>Utiliser le domaine par défaut</value>
   </data>
-  <data name="AddShortcutForm_BrowserArgsLabel" xml:space="preserve">
-    <value>Arguments du navigateur (Optionnel)</value>
+  <data name="AddShortcutForm_ReplaceWhitespace_Label" xml:space="preserve">
+    <value>Remplacer les espaces (Optionnel)</value>
   </data>
-  <data name="AddShortcutForm_BrowserArgsPlaceholder" xml:space="preserve">
-    <value>Arguments de lancement du navigateur, utilisez %1 pour l'URL</value>
+  <data name="AddShortcutForm_ReplaceWhitespace_Placeholder" xml:space="preserve">
+    <value>Spécifiez quel(s) caractère(s) remplace(nt) un espace</value>
   </data>
-  <data name="AddShortcutForm_BrowserPathLabel" xml:space="preserve">
+  <data name="AddShortcutForm_BrowserPath_Label" xml:space="preserve">
     <value>Navigateur</value>
   </data>
-  <data name="AddShortcutForm_BrowserPathDefault" xml:space="preserve">
+  <data name="AddShortcutForm_BrowserPath_Default" xml:space="preserve">
     <value>Par défaut</value>
+  </data>
+  <data name="AddShortcutForm_BrowserArgs_Label" xml:space="preserve">
+    <value>Arguments du navigateur (Optionnel)</value>
+  </data>
+  <data name="AddShortcutForm_BrowserArgs_Placeholder" xml:space="preserve">
+    <value>Arguments de lancement du navigateur, utilisez %1 pour l'URL</value>
   </data>
   <data name="AddShortcutForm_Save" xml:space="preserve">
     <value>Enregistrer</value>
   </data>
-  <data name="SearchShortcut_SubtitleTemplate" xml:space="preserve">
-    <value>Rechercher sur {engine}</value>
+  <data name="ShortcutItem_TitleTemplate" xml:space="preserve">
+    <value>{shortcut}</value>
   </data>
-  <data name="SearchShortcut_EditName" xml:space="preserve">
+  <data name="ShortcutItem_SubtitleTemplate" xml:space="preserve">
+    <value>Rechercher sur {shortcut}</value>
+  </data>
+  <data name="ShortcutItem_NameTemplate" xml:space="preserve">
+    <value>{shortcut}</value>
+  </data>
+  <data name="EditShortcutItem_TitleTemplate" xml:space="preserve">
     <value>Modifier le raccourci de recherche</value>
   </data>
-  <data name="SearchShortcut_EditTitle" xml:space="preserve">
+  <data name="EditShortcutItem_NameTemplate" xml:space="preserve">
     <value>Modifier le raccourci de recherche</value>
   </data>
-  <data name="SearchShortcut_DeleteName" xml:space="preserve">
+  <data name="DeleteShortcutItem_TitleTemplate" xml:space="preserve">
     <value>Supprimer</value>
   </data>
-  <data name="SearchShortcut_DeleteTitle" xml:space="preserve">
-    <value>Supprimer</value>
+  <data name="SearchWebPage_TitleTemplate" xml:space="preserve">
+    <value>{shortcut}</value>
   </data>
-  <data name="OpenHomePage_NameTemplate" xml:space="preserve">
-    <value>Ouvrir {engine}</value>
+  <data name="OpenHomepageItem_TitleTemplate" xml:space="preserve">
+    <value>Ouvrir {shortcut}</value>
   </data>
-  <data name="OpenHomePage_TitleTemplate" xml:space="preserve">
-    <value>Ouvrir {engine}</value>
+  <data name="OpenHomepageItem_NameTemplate" xml:space="preserve">
+    <value>Ouvrir {shortcut}</value>
   </data>
-  <data name="SearchQuery_NameTemplate" xml:space="preserve">
+  <data name="SearchQueryItem_TitleTemplate" xml:space="preserve">
+    <value>{query}</value>
+  </data>
+  <data name="SearchQueryItem_SubtitleTemplate" xml:space="preserve">
+    <value>Rechercher "{query}" sur {shortcut}</value>
+  </data>
+  <data name="SearchQueryItem_NameTemplate" xml:space="preserve">
     <value>Rechercher "{query}"</value>
-  </data>
-  <data name="SearchQuery_SubtitleTemplate" xml:space="preserve">
-    <value>Rechercher "{query}" sur {engine}</value>
   </data>
 </root>

--- a/CmdPalWebSearchShortcut/WebSearchShortcut/Properties/Resources.resx
+++ b/CmdPalWebSearchShortcut/WebSearchShortcut/Properties/Resources.resx
@@ -192,6 +192,9 @@
   <data name="ShortcutItem_NameTemplate" xml:space="preserve">
     <value>{shortcut}</value>
   </data>
+  <data name="ClearHistory_TitleTemplate" xml:space="preserve">
+    <value>Clear {shortcut}'s History</value>
+  </data>
   <data name="EditShortcutItem_TitleTemplate" xml:space="preserve">
     <value>Edit Search Shortcut</value>
   </data>
@@ -218,5 +221,8 @@
   </data>
   <data name="SearchQueryItem_NameTemplate" xml:space="preserve">
     <value>Search for "{query}"</value>
+  </data>
+  <data name="DeleteHistory_TitleTemplate" xml:space="preserve">
+    <value>Delete</value>
   </data>
 </root>

--- a/CmdPalWebSearchShortcut/WebSearchShortcut/Properties/Resources.resx
+++ b/CmdPalWebSearchShortcut/WebSearchShortcut/Properties/Resources.resx
@@ -156,6 +156,12 @@
   <data name="AddShortcutForm_SuggestionProvider_None" xml:space="preserve">
     <value>None</value>
   </data>
+  <data name="AddShortcutForm_RecordHistory_Label" xml:space="preserve">
+    <value>Search History</value>
+  </data>
+  <data name="AddShortcutForm_RecordHistory_Title" xml:space="preserve">
+    <value>Record history for this shortcut</value>
+  </data>
   <data name="AddShortcutForm_Homepage_Label" xml:space="preserve">
     <value>Custom Home Page (Optional)</value>
   </data>
@@ -224,5 +230,23 @@
   </data>
   <data name="DeleteHistory_TitleTemplate" xml:space="preserve">
     <value>Delete</value>
+  </data>
+  <data name="Settings_MaxDisplayCount_Label" xml:space="preserve">
+    <value>Max Search Results</value>
+  </data>
+  <data name="Settings_MaxDisplayCount_Description" xml:space="preserve">
+    <value>Maximum total items shown per search</value>
+  </data>
+  <data name="Settings_MaxDisplayCount_ErrorMessage" xml:space="preserve">
+    <value>Must be an integer greater than or equal to 1</value>
+  </data>
+  <data name="Settings_MaxHistoryDisplayCount_Label" xml:space="preserve">
+    <value>Max History Results</value>
+  </data>
+  <data name="Settings_MaxHistoryDisplayCount_Description" xml:space="preserve">
+    <value>Maximum number of history results shown during search; set to 0 to hide history. Any value exceeding “Max Search Results” is ignored.</value>
+  </data>
+  <data name="Settings_MaxHistoryDisplayCount_ErrorMessage" xml:space="preserve">
+    <value>Must be an integer greater than or equal to 0</value>
   </data>
 </root>

--- a/CmdPalWebSearchShortcut/WebSearchShortcut/Properties/Resources.resx
+++ b/CmdPalWebSearchShortcut/WebSearchShortcut/Properties/Resources.resx
@@ -120,88 +120,103 @@
   <data name="WebSearchShortcut_DisplayName" xml:space="preserve">
     <value>WebSearchShortcut</value>
   </data>
-  <data name="AddShortcut_AddName" xml:space="preserve">
+  <data name="AddShortcutItem_Title" xml:space="preserve">
     <value>Add Search Shortcut</value>
   </data>
-  <data name="AddShortcut_AddTitle" xml:space="preserve">
+  <data name="AddShortcutItem_Name" xml:space="preserve">
     <value>Add Search Shortcut</value>
   </data>
-  <data name="AddShortcutForm_NameLabel" xml:space="preserve">
+  <data name="AddShortcutPage_Title_Add" xml:space="preserve">
+    <value>Add Search Shortcut</value>
+  </data>
+  <data name="AddShortcutPage_Title_Edit" xml:space="preserve">
+    <value>Edit Search Shortcut</value>
+  </data>
+  <data name="AddShortcutForm_Name_Label" xml:space="preserve">
     <value>Name</value>
   </data>
-  <data name="AddShortcutForm_NameErrorMessage" xml:space="preserve">
+  <data name="AddShortcutForm_Name_ErrorMessage" xml:space="preserve">
     <value>Name is required</value>
   </data>
-  <data name="AddShortcutForm_UrlLabel" xml:space="preserve">
+  <data name="AddShortcutForm_Url_Label" xml:space="preserve">
     <value>URL</value>
   </data>
-  <data name="AddShortcutForm_UrlPlaceholder" xml:space="preserve">
+  <data name="AddShortcutForm_Url_Placeholder" xml:space="preserve">
     <value>Use %s in the URL for the search term</value>
   </data>
-  <data name="AddShortcutForm_UrlErrorMessage" xml:space="preserve">
+  <data name="AddShortcutForm_Url_ErrorMessage" xml:space="preserve">
     <value>URL is required</value>
   </data>
-  <data name="AddShortcutForm_SuggestionProviderLabel" xml:space="preserve">
+  <data name="AddShortcutForm_SuggestionProvider_Label" xml:space="preserve">
     <value>Suggestion Provider</value>
   </data>
-  <data name="AddShortcutForm_SuggestionProviderPlaceholder" xml:space="preserve">
+  <data name="AddShortcutForm_SuggestionProvider_Placeholder" xml:space="preserve">
     <value>Invalid Suggestion Provider</value>
   </data>
-  <data name="AddShortcutForm_SuggestionProviderNone" xml:space="preserve">
+  <data name="AddShortcutForm_SuggestionProvider_None" xml:space="preserve">
     <value>None</value>
   </data>
-  <data name="AddShortcutForm_ReplaceWhitespaceLabel" xml:space="preserve">
-    <value>Replace Whitespace (Optional)</value>
-  </data>
-  <data name="AddShortcutForm_ReplaceWhitespacePlaceholder" xml:space="preserve">
-    <value>Specify which character(s) to replace a space</value>
-  </data>
-  <data name="AddShortcutForm_HomepageLabel" xml:space="preserve">
+  <data name="AddShortcutForm_Homepage_Label" xml:space="preserve">
     <value>Custom Home Page (Optional)</value>
   </data>
-  <data name="AddShortcutForm_HomepagePlaceholder" xml:space="preserve">
+  <data name="AddShortcutForm_Homepage_Placeholder" xml:space="preserve">
     <value>Use domain by default</value>
   </data>
-  <data name="AddShortcutForm_BrowserArgsLabel" xml:space="preserve">
-    <value>Browser Arguments (Optional)</value>
+  <data name="AddShortcutForm_ReplaceWhitespace_Label" xml:space="preserve">
+    <value>Replace Whitespace (Optional)</value>
   </data>
-  <data name="AddShortcutForm_BrowserArgsPlaceholder" xml:space="preserve">
-    <value>Browser launch arguments, use %1 for URL</value>
+  <data name="AddShortcutForm_ReplaceWhitespace_Placeholder" xml:space="preserve">
+    <value>Specify which character(s) to replace a space</value>
   </data>
-  <data name="AddShortcutForm_BrowserPathLabel" xml:space="preserve">
+  <data name="AddShortcutForm_BrowserPath_Label" xml:space="preserve">
     <value>Browser</value>
   </data>
-  <data name="AddShortcutForm_BrowserPathDefault" xml:space="preserve">
+  <data name="AddShortcutForm_BrowserPath_Default" xml:space="preserve">
     <value>Default</value>
+  </data>
+  <data name="AddShortcutForm_BrowserArgs_Label" xml:space="preserve">
+    <value>Browser Arguments (Optional)</value>
+  </data>
+  <data name="AddShortcutForm_BrowserArgs_Placeholder" xml:space="preserve">
+    <value>Browser launch arguments, use %1 for URL</value>
   </data>
   <data name="AddShortcutForm_Save" xml:space="preserve">
     <value>Save</value>
   </data>
-  <data name="SearchShortcut_SubtitleTemplate" xml:space="preserve">
-    <value>Search {engine}</value>
+  <data name="ShortcutItem_TitleTemplate" xml:space="preserve">
+    <value>{shortcut}</value>
   </data>
-  <data name="SearchShortcut_EditName" xml:space="preserve">
+  <data name="ShortcutItem_SubtitleTemplate" xml:space="preserve">
+    <value>Search {shortcut}</value>
+  </data>
+  <data name="ShortcutItem_NameTemplate" xml:space="preserve">
+    <value>{shortcut}</value>
+  </data>
+  <data name="EditShortcutItem_TitleTemplate" xml:space="preserve">
     <value>Edit Search Shortcut</value>
   </data>
-  <data name="SearchShortcut_EditTitle" xml:space="preserve">
+  <data name="EditShortcutItem_NameTemplate" xml:space="preserve">
     <value>Edit Search Shortcut</value>
   </data>
-  <data name="SearchShortcut_DeleteName" xml:space="preserve">
+  <data name="DeleteShortcutItem_TitleTemplate" xml:space="preserve">
     <value>Delete</value>
   </data>
-  <data name="SearchShortcut_DeleteTitle" xml:space="preserve">
-    <value>Delete</value>
+  <data name="SearchWebPage_TitleTemplate" xml:space="preserve">
+    <value>{shortcut}</value>
   </data>
-  <data name="OpenHomePage_NameTemplate" xml:space="preserve">
-    <value>Open {engine}</value>
+  <data name="OpenHomepageItem_TitleTemplate" xml:space="preserve">
+    <value>Open {shortcut}</value>
   </data>
-  <data name="OpenHomePage_TitleTemplate" xml:space="preserve">
-    <value>Open {engine}</value>
+  <data name="OpenHomepageItem_NameTemplate" xml:space="preserve">
+    <value>Open {shortcut}</value>
   </data>
-  <data name="SearchQuery_NameTemplate" xml:space="preserve">
+  <data name="SearchQueryItem_TitleTemplate" xml:space="preserve">
+    <value>{query}</value>
+  </data>
+  <data name="SearchQueryItem_SubtitleTemplate" xml:space="preserve">
+    <value>Search {shortcut} for "{query}"</value>
+  </data>
+  <data name="SearchQueryItem_NameTemplate" xml:space="preserve">
     <value>Search for "{query}"</value>
-  </data>
-  <data name="SearchQuery_SubtitleTemplate" xml:space="preserve">
-    <value>Search {engine} for "{query}"</value>
   </data>
 </root>

--- a/CmdPalWebSearchShortcut/WebSearchShortcut/Properties/Resources.zh-CN.resx
+++ b/CmdPalWebSearchShortcut/WebSearchShortcut/Properties/Resources.zh-CN.resx
@@ -192,6 +192,9 @@
   <data name="ShortcutItem_NameTemplate" xml:space="preserve">
     <value>{shortcut}</value>
   </data>
+  <data name="ClearHistory_TitleTemplate" xml:space="preserve">
+    <value />
+  </data>
   <data name="EditShortcutItem_TitleTemplate" xml:space="preserve">
     <value>编辑搜索捷径</value>
   </data>
@@ -218,5 +221,8 @@
   </data>
   <data name="SearchQueryItem_NameTemplate" xml:space="preserve">
     <value>搜索“{query}”</value>
+  </data>
+  <data name="DeleteHistory_TitleTemplate" xml:space="preserve">
+    <value />
   </data>
 </root>

--- a/CmdPalWebSearchShortcut/WebSearchShortcut/Properties/Resources.zh-CN.resx
+++ b/CmdPalWebSearchShortcut/WebSearchShortcut/Properties/Resources.zh-CN.resx
@@ -120,88 +120,103 @@
   <data name="WebSearchShortcut_DisplayName" xml:space="preserve">
     <value>WebSearchShortcut</value>
   </data>
-  <data name="AddShortcut_AddName" xml:space="preserve">
+  <data name="AddShortcutItem_Title" xml:space="preserve">
     <value>添加搜索捷径（Shortcut）</value>
   </data>
-  <data name="AddShortcut_AddTitle" xml:space="preserve">
+  <data name="AddShortcutItem_Name" xml:space="preserve">
     <value>添加搜索捷径</value>
   </data>
-  <data name="AddShortcutForm_NameLabel" xml:space="preserve">
+  <data name="AddShortcutPage_Title_Add" xml:space="preserve">
+    <value>添加搜索捷径</value>
+  </data>
+  <data name="AddShortcutPage_Title_Edit" xml:space="preserve">
+    <value>编辑搜索捷径</value>
+  </data>
+  <data name="AddShortcutForm_Name_Label" xml:space="preserve">
     <value>名称</value>
   </data>
-  <data name="AddShortcutForm_NameErrorMessage" xml:space="preserve">
+  <data name="AddShortcutForm_Name_ErrorMessage" xml:space="preserve">
     <value>名称为必填项</value>
   </data>
-  <data name="AddShortcutForm_UrlLabel" xml:space="preserve">
+  <data name="AddShortcutForm_Url_Label" xml:space="preserve">
     <value>URL</value>
   </data>
-  <data name="AddShortcutForm_UrlPlaceholder" xml:space="preserve">
+  <data name="AddShortcutForm_Url_Placeholder" xml:space="preserve">
     <value>在 URL 中使用 %s 作为搜索词占位符</value>
   </data>
-  <data name="AddShortcutForm_UrlErrorMessage" xml:space="preserve">
+  <data name="AddShortcutForm_Url_ErrorMessage" xml:space="preserve">
     <value>URL 为必填项</value>
   </data>
-  <data name="AddShortcutForm_SuggestionProviderLabel" xml:space="preserve">
+  <data name="AddShortcutForm_SuggestionProvider_Label" xml:space="preserve">
     <value>搜索建议来源</value>
   </data>
-  <data name="AddShortcutForm_SuggestionProviderPlaceholder" xml:space="preserve">
+  <data name="AddShortcutForm_SuggestionProvider_Placeholder" xml:space="preserve">
     <value>无效的搜索建议来源</value>
   </data>
-  <data name="AddShortcutForm_SuggestionProviderNone" xml:space="preserve">
+  <data name="AddShortcutForm_SuggestionProvider_None" xml:space="preserve">
     <value>无</value>
   </data>
-  <data name="AddShortcutForm_ReplaceWhitespaceLabel" xml:space="preserve">
-    <value>替换空格（可选）</value>
-  </data>
-  <data name="AddShortcutForm_ReplaceWhitespacePlaceholder" xml:space="preserve">
-    <value>指定用于替换空格的字符</value>
-  </data>
-  <data name="AddShortcutForm_HomepageLabel" xml:space="preserve">
+  <data name="AddShortcutForm_Homepage_Label" xml:space="preserve">
     <value>自定义主页（可选）</value>
   </data>
-  <data name="AddShortcutForm_HomepagePlaceholder" xml:space="preserve">
+  <data name="AddShortcutForm_Homepage_Placeholder" xml:space="preserve">
     <value>默认使用主域名</value>
   </data>
-  <data name="AddShortcutForm_BrowserArgsLabel" xml:space="preserve">
-    <value>浏览器参数（可选）</value>
+  <data name="AddShortcutForm_ReplaceWhitespace_Label" xml:space="preserve">
+    <value>替换空格（可选）</value>
   </data>
-  <data name="AddShortcutForm_BrowserArgsPlaceholder" xml:space="preserve">
-    <value>浏览器启动参数，使用 %1 作为 URL 占位符</value>
+  <data name="AddShortcutForm_ReplaceWhitespace_Placeholder" xml:space="preserve">
+    <value>指定用于替换空格的字符</value>
   </data>
-  <data name="AddShortcutForm_BrowserPathLabel" xml:space="preserve">
+  <data name="AddShortcutForm_BrowserPath_Label" xml:space="preserve">
     <value>浏览器</value>
   </data>
-  <data name="AddShortcutForm_BrowserPathDefault" xml:space="preserve">
+  <data name="AddShortcutForm_BrowserPath_Default" xml:space="preserve">
     <value>默认</value>
+  </data>
+  <data name="AddShortcutForm_BrowserArgs_Label" xml:space="preserve">
+    <value>浏览器参数（可选）</value>
+  </data>
+  <data name="AddShortcutForm_BrowserArgs_Placeholder" xml:space="preserve">
+    <value>浏览器启动参数，使用 %1 作为 URL 占位符</value>
   </data>
   <data name="AddShortcutForm_Save" xml:space="preserve">
     <value>保存</value>
   </data>
-  <data name="SearchShortcut_SubtitleTemplate" xml:space="preserve">
-    <value>搜索 {engine}</value>
+  <data name="ShortcutItem_TitleTemplate" xml:space="preserve">
+    <value>{shortcut}</value>
   </data>
-  <data name="SearchShortcut_EditName" xml:space="preserve">
+  <data name="ShortcutItem_SubtitleTemplate" xml:space="preserve">
+    <value>搜索 {shortcut}</value>
+  </data>
+  <data name="ShortcutItem_NameTemplate" xml:space="preserve">
+    <value>{shortcut}</value>
+  </data>
+  <data name="EditShortcutItem_TitleTemplate" xml:space="preserve">
     <value>编辑搜索捷径</value>
   </data>
-  <data name="SearchShortcut_EditTitle" xml:space="preserve">
+  <data name="EditShortcutItem_NameTemplate" xml:space="preserve">
     <value>编辑搜索捷径</value>
   </data>
-  <data name="SearchShortcut_DeleteName" xml:space="preserve">
+  <data name="DeleteShortcutItem_TitleTemplate" xml:space="preserve">
     <value>删除</value>
   </data>
-  <data name="SearchShortcut_DeleteTitle" xml:space="preserve">
-    <value>删除</value>
+  <data name="SearchWebPage_TitleTemplate" xml:space="preserve">
+    <value>{shortcut}</value>
   </data>
-  <data name="OpenHomePage_NameTemplate" xml:space="preserve">
-    <value>打开 {engine}</value>
+  <data name="OpenHomepageItem_TitleTemplate" xml:space="preserve">
+    <value>打开 {shortcut}</value>
   </data>
-  <data name="OpenHomePage_TitleTemplate" xml:space="preserve">
-    <value>打开 {engine}</value>
+  <data name="OpenHomepageItem_NameTemplate" xml:space="preserve">
+    <value>打开 {shortcut}</value>
   </data>
-  <data name="SearchQuery_NameTemplate" xml:space="preserve">
+  <data name="SearchQueryItem_TitleTemplate" xml:space="preserve">
+    <value>{query}</value>
+  </data>
+  <data name="SearchQueryItem_SubtitleTemplate" xml:space="preserve">
+    <value>在 {shortcut} 中搜索“{query}”</value>
+  </data>
+  <data name="SearchQueryItem_NameTemplate" xml:space="preserve">
     <value>搜索“{query}”</value>
-  </data>
-  <data name="SearchQuery_SubtitleTemplate" xml:space="preserve">
-    <value>在 {engine} 中搜索“{query}”</value>
   </data>
 </root>

--- a/CmdPalWebSearchShortcut/WebSearchShortcut/Properties/Resources.zh-CN.resx
+++ b/CmdPalWebSearchShortcut/WebSearchShortcut/Properties/Resources.zh-CN.resx
@@ -156,6 +156,12 @@
   <data name="AddShortcutForm_SuggestionProvider_None" xml:space="preserve">
     <value>无</value>
   </data>
+  <data name="AddShortcutForm_RecordHistory_Label" xml:space="preserve">
+    <value />
+  </data>
+  <data name="AddShortcutForm_RecordHistory_Title" xml:space="preserve">
+    <value />
+  </data>
   <data name="AddShortcutForm_Homepage_Label" xml:space="preserve">
     <value>自定义主页（可选）</value>
   </data>
@@ -223,6 +229,24 @@
     <value>搜索“{query}”</value>
   </data>
   <data name="DeleteHistory_TitleTemplate" xml:space="preserve">
+    <value />
+  </data>
+  <data name="Settings_MaxDisplayCount_Label" xml:space="preserve">
+    <value />
+  </data>
+  <data name="Settings_MaxDisplayCount_Description" xml:space="preserve">
+    <value />
+  </data>
+  <data name="Settings_MaxDisplayCount_ErrorMessage" xml:space="preserve">
+    <value />
+  </data>
+  <data name="Settings_MaxHistoryDisplayCount_Label" xml:space="preserve">
+    <value />
+  </data>
+  <data name="Settings_MaxHistoryDisplayCount_Description" xml:space="preserve">
+    <value />
+  </data>
+  <data name="Settings_MaxHistoryDisplayCount_ErrorMessage" xml:space="preserve">
     <value />
   </data>
 </root>

--- a/CmdPalWebSearchShortcut/WebSearchShortcut/Properties/Resources.zh-TW.resx
+++ b/CmdPalWebSearchShortcut/WebSearchShortcut/Properties/Resources.zh-TW.resx
@@ -192,6 +192,9 @@
   <data name="ShortcutItem_NameTemplate" xml:space="preserve">
     <value>{shortcut}</value>
   </data>
+  <data name="ClearHistory_TitleTemplate" xml:space="preserve">
+    <value>清除 {shortcut} 的歷史紀錄</value>
+  </data>
   <data name="EditShortcutItem_TitleTemplate" xml:space="preserve">
     <value>編輯搜尋捷徑</value>
   </data>
@@ -218,5 +221,8 @@
   </data>
   <data name="SearchQueryItem_NameTemplate" xml:space="preserve">
     <value>搜尋「{query}」</value>
+  </data>
+  <data name="DeleteHistory_TitleTemplate" xml:space="preserve">
+    <value>將「{query}」從歷史紀錄刪除</value>
   </data>
 </root>

--- a/CmdPalWebSearchShortcut/WebSearchShortcut/Properties/Resources.zh-TW.resx
+++ b/CmdPalWebSearchShortcut/WebSearchShortcut/Properties/Resources.zh-TW.resx
@@ -120,88 +120,103 @@
   <data name="WebSearchShortcut_DisplayName" xml:space="preserve">
     <value>網頁搜尋捷徑</value>
   </data>
-  <data name="AddShortcut_AddName" xml:space="preserve">
+  <data name="AddShortcutItem_Title" xml:space="preserve">
     <value>+新增搜尋捷徑</value>
   </data>
-  <data name="AddShortcut_AddTitle" xml:space="preserve">
+  <data name="AddShortcutItem_Name" xml:space="preserve">
     <value>新增搜尋捷徑</value>
   </data>
-  <data name="AddShortcutForm_NameLabel" xml:space="preserve">
+  <data name="AddShortcutPage_Title_Add" xml:space="preserve">
+    <value>新增搜尋捷徑</value>
+  </data>
+  <data name="AddShortcutPage_Title_Edit" xml:space="preserve">
+    <value>編輯搜尋捷徑</value>
+  </data>
+  <data name="AddShortcutForm_Name_Label" xml:space="preserve">
     <value>名稱</value>
   </data>
-  <data name="AddShortcutForm_NameErrorMessage" xml:space="preserve">
+  <data name="AddShortcutForm_Name_ErrorMessage" xml:space="preserve">
     <value>必須填寫名稱</value>
   </data>
-  <data name="AddShortcutForm_UrlLabel" xml:space="preserve">
+  <data name="AddShortcutForm_Url_Label" xml:space="preserve">
     <value>網址</value>
   </data>
-  <data name="AddShortcutForm_UrlPlaceholder" xml:space="preserve">
+  <data name="AddShortcutForm_Url_Placeholder" xml:space="preserve">
     <value>搜尋引擎的網址，請用 %s 取代關鍵字的位置</value>
   </data>
-  <data name="AddShortcutForm_UrlErrorMessage" xml:space="preserve">
+  <data name="AddShortcutForm_Url_ErrorMessage" xml:space="preserve">
     <value>必須填寫網址</value>
   </data>
-  <data name="AddShortcutForm_SuggestionProviderLabel" xml:space="preserve">
+  <data name="AddShortcutForm_SuggestionProvider_Label" xml:space="preserve">
     <value>關鍵字建議來源</value>
   </data>
-  <data name="AddShortcutForm_SuggestionProviderPlaceholder" xml:space="preserve">
+  <data name="AddShortcutForm_SuggestionProvider_Placeholder" xml:space="preserve">
     <value>無效的關鍵字建議來源</value>
   </data>
-  <data name="AddShortcutForm_SuggestionProviderNone" xml:space="preserve">
+  <data name="AddShortcutForm_SuggestionProvider_None" xml:space="preserve">
     <value>無</value>
   </data>
-  <data name="AddShortcutForm_ReplaceWhitespaceLabel" xml:space="preserve">
-    <value>替換空白字元（可選）</value>
-  </data>
-  <data name="AddShortcutForm_ReplaceWhitespacePlaceholder" xml:space="preserve">
-    <value>搜尋關鍵字中的空白會被替換為這裡指定的字元</value>
-  </data>
-  <data name="AddShortcutForm_HomepageLabel" xml:space="preserve">
+  <data name="AddShortcutForm_Homepage_Label" xml:space="preserve">
     <value>自訂首頁（可選）</value>
   </data>
-  <data name="AddShortcutForm_HomepagePlaceholder" xml:space="preserve">
+  <data name="AddShortcutForm_Homepage_Placeholder" xml:space="preserve">
     <value>預設為網域</value>
   </data>
-  <data name="AddShortcutForm_BrowserArgsLabel" xml:space="preserve">
-    <value>瀏覽器參數（可選）</value>
+  <data name="AddShortcutForm_ReplaceWhitespace_Label" xml:space="preserve">
+    <value>替換空白字元（可選）</value>
   </data>
-  <data name="AddShortcutForm_BrowserArgsPlaceholder" xml:space="preserve">
-    <value>瀏覽器啟動參數，請用 %1 取代網址的位置</value>
+  <data name="AddShortcutForm_ReplaceWhitespace_Placeholder" xml:space="preserve">
+    <value>搜尋關鍵字中的空白會被替換為這裡指定的字元</value>
   </data>
-  <data name="AddShortcutForm_BrowserPathLabel" xml:space="preserve">
+  <data name="AddShortcutForm_BrowserPath_Label" xml:space="preserve">
     <value>瀏覽器</value>
   </data>
-  <data name="AddShortcutForm_BrowserPathDefault" xml:space="preserve">
+  <data name="AddShortcutForm_BrowserPath_Default" xml:space="preserve">
     <value>使用者預設瀏覽器</value>
+  </data>
+  <data name="AddShortcutForm_BrowserArgs_Label" xml:space="preserve">
+    <value>瀏覽器參數（可選）</value>
+  </data>
+  <data name="AddShortcutForm_BrowserArgs_Placeholder" xml:space="preserve">
+    <value>瀏覽器啟動參數，請用 %1 取代網址的位置</value>
   </data>
   <data name="AddShortcutForm_Save" xml:space="preserve">
     <value>儲存</value>
   </data>
-  <data name="SearchShortcut_SubtitleTemplate" xml:space="preserve">
-    <value>在 {engine} 上搜尋</value>
+  <data name="ShortcutItem_TitleTemplate" xml:space="preserve">
+    <value>{shortcut}</value>
   </data>
-  <data name="SearchShortcut_EditName" xml:space="preserve">
+  <data name="ShortcutItem_SubtitleTemplate" xml:space="preserve">
+    <value>在 {shortcut} 上搜尋</value>
+  </data>
+  <data name="ShortcutItem_NameTemplate" xml:space="preserve">
+    <value>{shortcut}</value>
+  </data>
+  <data name="EditShortcutItem_TitleTemplate" xml:space="preserve">
     <value>編輯搜尋捷徑</value>
   </data>
-  <data name="SearchShortcut_EditTitle" xml:space="preserve">
+  <data name="EditShortcutItem_NameTemplate" xml:space="preserve">
     <value>編輯搜尋捷徑</value>
   </data>
-  <data name="SearchShortcut_DeleteName" xml:space="preserve">
+  <data name="DeleteShortcutItem_TitleTemplate" xml:space="preserve">
     <value>刪除搜尋捷徑</value>
   </data>
-  <data name="SearchShortcut_DeleteTitle" xml:space="preserve">
-    <value>刪除搜尋捷徑</value>
+  <data name="SearchWebPage_TitleTemplate" xml:space="preserve">
+    <value>{shortcut}</value>
   </data>
-  <data name="OpenHomePage_NameTemplate" xml:space="preserve">
-    <value>開啟 {engine} 首頁</value>
+  <data name="OpenHomepageItem_TitleTemplate" xml:space="preserve">
+    <value>開啟 {shortcut} 首頁</value>
   </data>
-  <data name="OpenHomePage_TitleTemplate" xml:space="preserve">
-    <value>開啟 {engine} 首頁</value>
+  <data name="OpenHomepageItem_NameTemplate" xml:space="preserve">
+    <value>開啟 {shortcut} 首頁</value>
   </data>
-  <data name="SearchQuery_NameTemplate" xml:space="preserve">
+  <data name="SearchQueryItem_TitleTemplate" xml:space="preserve">
+    <value>{query}</value>
+  </data>
+  <data name="SearchQueryItem_SubtitleTemplate" xml:space="preserve">
+    <value>在 {shortcut} 上搜尋「{query}」</value>
+  </data>
+  <data name="SearchQueryItem_NameTemplate" xml:space="preserve">
     <value>搜尋「{query}」</value>
-  </data>
-  <data name="SearchQuery_SubtitleTemplate" xml:space="preserve">
-    <value>在 {engine} 上搜尋「{query}」</value>
   </data>
 </root>

--- a/CmdPalWebSearchShortcut/WebSearchShortcut/Properties/Resources.zh-TW.resx
+++ b/CmdPalWebSearchShortcut/WebSearchShortcut/Properties/Resources.zh-TW.resx
@@ -156,6 +156,12 @@
   <data name="AddShortcutForm_SuggestionProvider_None" xml:space="preserve">
     <value>無</value>
   </data>
+  <data name="AddShortcutForm_RecordHistory_Label" xml:space="preserve">
+    <value>搜尋歷史</value>
+  </data>
+  <data name="AddShortcutForm_RecordHistory_Title" xml:space="preserve">
+    <value>記錄此捷徑的搜尋歷史</value>
+  </data>
   <data name="AddShortcutForm_Homepage_Label" xml:space="preserve">
     <value>自訂首頁（可選）</value>
   </data>
@@ -224,5 +230,23 @@
   </data>
   <data name="DeleteHistory_TitleTemplate" xml:space="preserve">
     <value>將「{query}」從歷史紀錄刪除</value>
+  </data>
+  <data name="Settings_MaxDisplayCount_Label" xml:space="preserve">
+    <value>搜尋結果顯示上限</value>
+  </data>
+  <data name="Settings_MaxDisplayCount_Description" xml:space="preserve">
+    <value>一次搜尋最多顯示的總項目數</value>
+  </data>
+  <data name="Settings_MaxDisplayCount_ErrorMessage" xml:space="preserve">
+    <value>必須是大於或等於 1 的整數</value>
+  </data>
+  <data name="Settings_MaxHistoryDisplayCount_Label" xml:space="preserve">
+    <value>搜尋歷史顯示上限</value>
+  </data>
+  <data name="Settings_MaxHistoryDisplayCount_Description" xml:space="preserve">
+    <value>搜尋時顯示的歷史結果上限；設為 0 不顯示歷史。超過「搜尋結果顯示上限」的部分會被忽略</value>
+  </data>
+  <data name="Settings_MaxHistoryDisplayCount_ErrorMessage" xml:space="preserve">
+    <value>必須是大於或等於 0 的整數</value>
   </data>
 </root>

--- a/CmdPalWebSearchShortcut/WebSearchShortcut/WebSearchShortcutCommandsProvider.cs
+++ b/CmdPalWebSearchShortcut/WebSearchShortcut/WebSearchShortcutCommandsProvider.cs
@@ -24,7 +24,7 @@ public partial class WebSearchShortcutCommandsProvider : CommandProvider
     public WebSearchShortcutCommandsProvider()
     {
         DisplayName = Resources.WebSearchShortcut_DisplayName;
-        Icon = IconHelpers.FromRelativePath("Assets\\Search.png");
+        Icon = Icons.Logo;
 
         var addShortcutPage = new AddShortcutPage(null)
         {
@@ -34,7 +34,7 @@ public partial class WebSearchShortcutCommandsProvider : CommandProvider
         _addShortcutItem = new CommandItem(addShortcutPage)
         {
             Title = Resources.AddShortcutItem_Title,
-            Icon = IconHelpers.FromRelativePath("Assets\\SearchAdd.png")
+            Icon = Icons.AddShortcut
         };
     }
 

--- a/CmdPalWebSearchShortcut/WebSearchShortcut/WebSearchShortcutCommandsProvider.cs
+++ b/CmdPalWebSearchShortcut/WebSearchShortcut/WebSearchShortcutCommandsProvider.cs
@@ -17,7 +17,7 @@ namespace WebSearchShortcut;
 
 public partial class WebSearchShortcutCommandsProvider : CommandProvider
 {
-    private readonly AddShortcutPage _addShortcutPage = new(null);
+    private readonly ICommandItem _addShortcutItem;
     private ICommandItem[] _topLevelCommands = [];
     private Storage? _storage;
 
@@ -26,7 +26,16 @@ public partial class WebSearchShortcutCommandsProvider : CommandProvider
         DisplayName = Resources.WebSearchShortcut_DisplayName;
         Icon = IconHelpers.FromRelativePath("Assets\\Search.png");
 
-        _addShortcutPage.AddedCommand += AddNewCommand_AddedCommand;
+        var addShortcutPage = new AddShortcutPage(null)
+        {
+            Name = Resources.AddShortcutItem_Name
+        };
+        addShortcutPage.AddedCommand += AddNewCommand_AddedCommand;
+        _addShortcutItem = new CommandItem(addShortcutPage)
+        {
+            Title = Resources.AddShortcutItem_Title,
+            Icon = IconHelpers.FromRelativePath("Assets\\SearchAdd.png")
+        };
     }
 
     public override ICommandItem[] TopLevelCommands()
@@ -91,7 +100,7 @@ public partial class WebSearchShortcutCommandsProvider : CommandProvider
 
     private void ReloadCommands()
     {
-        List<CommandItem> items = [new CommandItem(_addShortcutPage)];
+        List<ICommandItem> items = [_addShortcutItem];
 
         if (_storage is null)
         {
@@ -122,13 +131,20 @@ public partial class WebSearchShortcutCommandsProvider : CommandProvider
 
     private CommandItem CreateCommandItem(WebSearchShortcutDataEntry shortcut)
     {
-        var editShortcutPage = new AddShortcutPage(shortcut);
+        var editShortcutPage = new AddShortcutPage(shortcut)
+        {
+            Name = StringFormatter.Format(Resources.EditShortcutItem_NameTemplate, new() { ["shortcut"] = shortcut.Name }),
+        };
         editShortcutPage.AddedCommand += Edit_AddedCommand;
-        var editCommand = new CommandContextItem(editShortcutPage) { Icon = Icons.Edit };
+        var editCommand = new CommandContextItem(editShortcutPage)
+        {
+            Title = StringFormatter.Format(Resources.EditShortcutItem_TitleTemplate, new() { ["shortcut"] = shortcut.Name }),
+            Icon = Icons.Edit
+        };
 
         var deleteCommand = new CommandContextItem(
-            title: Resources.SearchShortcut_DeleteTitle,
-            name: Resources.SearchShortcut_DeleteName,
+            title: StringFormatter.Format(Resources.DeleteShortcutItem_TitleTemplate, new() { ["shortcut"] = shortcut.Name }),
+            name: $"[UNREACHABLE] DeleteCommand.Name - shortcut='{shortcut.Name}'",
             action: () =>
             {
                 if (_storage != null)
@@ -140,15 +156,23 @@ public partial class WebSearchShortcutCommandsProvider : CommandProvider
                     SaveAndRefresh();
                 }
             },
-            result: CommandResult.KeepOpen())
+            result: CommandResult.KeepOpen()
+        )
         {
             Icon = Icons.Delete,
             IsCritical = true
         };
 
-        var commandItem = new CommandItem(new SearchWebPage(shortcut))
+        var commandItem = new CommandItem(
+            new SearchWebPage(shortcut)
+            {
+                Name = StringFormatter.Format(Resources.ShortcutItem_NameTemplate, new() { ["shortcut"] = shortcut.Name })
+            }
+        )
         {
-            Subtitle = StringFormatter.Format(Resources.SearchShortcut_SubtitleTemplate, new() { ["engine"] = shortcut.Name }),
+            Title = StringFormatter.Format(Resources.ShortcutItem_TitleTemplate, new() { ["shortcut"] = shortcut.Name }),
+            Subtitle = StringFormatter.Format(Resources.ShortcutItem_SubtitleTemplate, new() { ["shortcut"] = shortcut.Name }),
+            Icon = IconService.GetIconInfo(shortcut),
             MoreCommands = [editCommand, deleteCommand]
         };
 

--- a/CmdPalWebSearchShortcut/WebSearchShortcut/WebSearchShortcutCommandsProvider.cs
+++ b/CmdPalWebSearchShortcut/WebSearchShortcut/WebSearchShortcutCommandsProvider.cs
@@ -18,14 +18,18 @@ namespace WebSearchShortcut;
 
 public partial class WebSearchShortcutCommandsProvider : CommandProvider
 {
+    private static readonly SettingsManager _settingsManager = new();
+
     private readonly ICommandItem _addShortcutItem;
     private ICommandItem[] _topLevelCommands = [];
+
     private Storage? _storage;
 
     public WebSearchShortcutCommandsProvider()
     {
         DisplayName = Resources.WebSearchShortcut_DisplayName;
         Icon = Icons.Logo;
+        Settings = _settingsManager.Settings;
 
         var addShortcutPage = new AddShortcutPage(null)
         {
@@ -132,7 +136,7 @@ public partial class WebSearchShortcutCommandsProvider : CommandProvider
 
     private CommandItem CreateCommandItem(WebSearchShortcutDataEntry shortcut)
     {
-        var searchWebPage = new SearchWebPage(shortcut)
+        var searchWebPage = new SearchWebPage(shortcut, _settingsManager)
         {
             Name = StringFormatter.Format(Resources.ShortcutItem_NameTemplate, new() { ["shortcut"] = shortcut.Name })
         };

--- a/CmdPalWebSearchShortcut/WebSearchShortcut/WebSearchShortcutDataEntry.cs
+++ b/CmdPalWebSearchShortcut/WebSearchShortcut/WebSearchShortcutDataEntry.cs
@@ -12,9 +12,9 @@ internal sealed class WebSearchShortcutDataEntry
     public string Url { get; set; } = string.Empty;
     // public string[]? Urls { get; set; }
     public string? SuggestionProvider { get; set; }
-    public string? ReplaceWhitespace { get; set; }
-    public string? IconUrl { get; set; }
     public string? HomePage { get; set; }
+    public string? IconUrl { get; set; }
+    public string? ReplaceWhitespace { get; set; }
     public string? BrowserPath { get; set; }
     public string? BrowserArgs { get; set; }
 

--- a/CmdPalWebSearchShortcut/WebSearchShortcut/WebSearchShortcutDataEntry.cs
+++ b/CmdPalWebSearchShortcut/WebSearchShortcut/WebSearchShortcutDataEntry.cs
@@ -12,6 +12,7 @@ internal sealed class WebSearchShortcutDataEntry
     public string Url { get; set; } = string.Empty;
     // public string[]? Urls { get; set; }
     public string? SuggestionProvider { get; set; }
+    public bool? RecordHistory { get; set; }
     public string? HomePage { get; set; }
     public string? IconUrl { get; set; }
     public string? ReplaceWhitespace { get; set; }


### PR DESCRIPTION
## Summary

This PR adds “**History**” and “**Histroy × Suggestions**” capabilities , and provides several tuning options to control the ratio and display caps of history vs. suggestions in the list. It also adds single-entry deletion and one-click purge of all history for a specific shortcut.

## What was done

### Save search history

* Record user input when executing a search (controlled per-shortcut by `RecordHistory`).
* Added `HistoryEntry` / `HistoryStorage` / `HistoryService` to encapsulate data structures, serialization, and file I/O.

### Show history and suggestions together

* Introduced `ItemIntegrate` to merge **Primary / History / Suggestions**, de-duplicate, and trim the list according to settings.

### Delete history

* Support deleting a single history entry.
* Support purging all history for a specified shortcut.

### Settings

* Added global settings: `MaxDisplayCount` (maximum number of items shown) and `MaxHistoryDisplayCount` (maximum number of history items shown).
* Added per-shortcut setting: `RecordHistory` (whether to record search history for that shortcut).

### UI updates

* Added a **“Record History”** toggle to the add/edit shortcut form.

## User impact (behavior changes)

* During search, users will see **history** and **suggestions** together. The number of history items displayed can be controlled via `MaxHistoryDisplayCount`.
* Users can turn off history recording in the shortcut settings (`RecordHistory: false`).
* Users can delete a single history entry from the UI or clear all history for that shortcut.

## ⚠️ Important items for review

### IntSetting and TextSetting label behavior

Because `Microsoft.CommandPalette.Extensions.Toolkit` does not include `IntSetting`, I implemented one modeled after `TextSetting`. I discovered that `TextSetting`’s **`Label` is not used at all** (it does not render in the UI), and I don’t know why it was designed that way. For **consistency**, `IntSetting` preserves the same “feature.” If you notice that the label does not appear, this is a **feature, not a bug**.

### History retention / auto-deletion

I did **not** add automatic history deletion. In testing, even with **1M** records there was **no user-facing performance impact**. If retention limits or auto-pruning are still desired, I can add them in a follow-up PR.

### Behavior when `RecordHistory` is turned off

Turning off `RecordHistory` **does not delete existing history**, and I believe it **should remain this way**. History is **keyed by the shortcut’s `Name`**. Even if we introduce an `Id` in the future, I don’t think we should rebind to `Id`; **multiple shortcuts with the same name sharing history is expected behavior**. Therefore, if one of several same-name shortcuts disables `RecordHistory`, auto-clearing the shared history would be unexpected. If users want to remove history, they can do so via the shortcut’s **More commands**.

### Renaming shortcuts and potential “ghost” history

If a shortcut is **renamed**, it can produce **ghost** history entries that remain in `History.json` but are no longer surfaced in the UI and cannot be deleted from there. This does not affect functionality, but it’s a **privacy concern**. I propose addressing it in a future PR.

### Naming and persistence files — please double-check

The functionality is complete, but this PR is submitted as **Draft** because it will **persist** the following settings/files. Once released, renaming would be very troublesome, so please carefully consider whether these names are appropriate:

* `settings.json`

  * `WebSearchShortcut.MaxDisplayCount`
  * `WebSearchShortcut.MaxHistoryDisplayCount`

* `WebSearchShortcut.json`

  * New per-shortcut field: `RecordHistory` (bool)

* New file

  * `WebSearchShortcut_history.json` (stores search history; fields: `Query`, `Timestamp`)

**Please provide feedback on:**

* Whether the key prefix `WebSearchShortcut.` and its casing are consistent with existing settings.
  Other projects use forms like `websearch`, `timeDate`.
* Whether the two cap names (`MaxDisplayCount`, `MaxHistoryDisplayCount`) are clear.
* Whether `RecordHistory` is clear.
* Whether the file name `WebSearchShortcut_history.json` is clear, or if it should be `WebSearchShortcut_History.json`.
* Whether `WebSearchShortcut_history.json` should use field names **`Query`** and **`Timestamp`** (as in this PR) vs. aligning with the `websearch` project’s **`SearchString`** + **`Timestamp`**.