### PR TITLE
feat: add fallback commands

### DIFF
--- a/CmdPalWebSearchShortcut/WebSearchShortcut/Commands/SearchWebCommand.cs
+++ b/CmdPalWebSearchShortcut/WebSearchShortcut/Commands/SearchWebCommand.cs
@@ -5,7 +5,14 @@ namespace WebSearchShortcut.Commands;
 
 internal sealed partial class SearchWebCommand : InvokableCommand
 {
-    private readonly string _query;
+    public new string Id
+    {
+        get => base.Id;
+        set => base.Id = value;
+    }
+
+    public string Query { get; internal set; } = string.Empty;
+
     private readonly WebSearchShortcutDataEntry _shortcut;
     private readonly BrowserExecutionInfo _browserInfo;
     // private readonly SettingsManager _settingsManager;
@@ -14,7 +21,8 @@ internal sealed partial class SearchWebCommand : InvokableCommand
     {
         Name = $"[UNBOUND] {nameof(SearchWebCommand)}.{nameof(Name)} required - shortcut='{shortcut.Name}', query='{query}'";
 
-        _query = query;
+        Query = query;
+
         _shortcut = shortcut;
         _browserInfo = new BrowserExecutionInfo(shortcut);
         // _settingsManager = settingsManager;
@@ -22,7 +30,7 @@ internal sealed partial class SearchWebCommand : InvokableCommand
 
     public override CommandResult Invoke()
     {
-        if (!ShellHelpers.OpenCommandInShell(_browserInfo.Path, _browserInfo.ArgumentsPattern, WebSearchShortcutDataEntry.GetSearchUrl(_shortcut, _query)))
+        if (!ShellHelpers.OpenCommandInShell(_browserInfo.Path, _browserInfo.ArgumentsPattern, WebSearchShortcutDataEntry.GetSearchUrl(_shortcut, Query)))
         {
             // TODO GH# 138 --> actually display feedback from the extension somewhere.
             return CommandResult.KeepOpen();

--- a/CmdPalWebSearchShortcut/WebSearchShortcut/Pages/FallbackSearchWebItem.cs
+++ b/CmdPalWebSearchShortcut/WebSearchShortcut/Pages/FallbackSearchWebItem.cs
@@ -1,0 +1,52 @@
+﻿using Microsoft.CommandPalette.Extensions.Toolkit;
+using WebSearchShortcut.Commands;
+using WebSearchShortcut.Helpers;
+using WebSearchShortcut.Properties;
+using WebSearchShortcut.Services;
+
+namespace WebSearchShortcut;
+
+internal sealed partial class FallbackSearchWebItem : FallbackCommandItem
+{
+    private readonly SearchWebCommand _searchWebCommand;
+    private readonly WebSearchShortcutDataEntry _shortcut;
+
+    public FallbackSearchWebItem(WebSearchShortcutDataEntry shortcut)
+        : base(new SearchWebCommand(shortcut, string.Empty) { Id = $"{shortcut.Id}.fallback" }, shortcut.Name)
+    {
+        _shortcut = shortcut;
+
+        _searchWebCommand = (SearchWebCommand) Command!;
+        _searchWebCommand.Name = string.Empty;
+
+        Title = string.Empty;
+        Subtitle = string.Empty;
+        Icon = IconService.GetIconInfo(shortcut);
+        MoreCommands = [
+            new CommandContextItem(
+                new OpenHomePageCommand(_shortcut)
+                {
+                    Name = StringFormatter.Format(Resources.OpenHomepageItem_NameTemplate, new() { ["shortcut"] = _shortcut.Name })
+                }
+            )
+            {
+                Title = StringFormatter.Format(Resources.OpenHomepageItem_TitleTemplate, new() { ["shortcut"] = _shortcut.Name }),
+                Icon = Icons.Home
+            }
+        ];
+    }
+
+    public override void UpdateQuery(string query)
+    {
+        bool isEmpty = string.IsNullOrWhiteSpace(query);
+
+        // Order matters: update command state before Title. (Verified 2025-08-21)
+        // Title may be derived from/overwritten by Command.Name.
+        // Set Command.Name before Title to avoid stale or inconsistent UI.
+        _searchWebCommand.Name = isEmpty ? string.Empty : StringFormatter.Format(Resources.SearchQueryItem_NameTemplate, new() { ["shortcut"] = _shortcut.Name, ["query"] = query });
+        _searchWebCommand.Query = query;
+
+        Title = isEmpty ? string.Empty : StringFormatter.Format(Resources.SearchQueryItem_TitleTemplate, new() { ["shortcut"] = _shortcut.Name, ["query"] = query });
+        Subtitle = isEmpty ? string.Empty : StringFormatter.Format(Resources.SearchQueryItem_SubtitleTemplate, new() { ["shortcut"] = _shortcut.Name, ["query"] = query });
+    }
+}

--- a/CmdPalWebSearchShortcut/WebSearchShortcut/WebSearchShortcutCommandsProvider.cs
+++ b/CmdPalWebSearchShortcut/WebSearchShortcut/WebSearchShortcutCommandsProvider.cs
@@ -20,6 +20,7 @@ public partial class WebSearchShortcutCommandsProvider : CommandProvider
 {
     private readonly ICommandItem _addShortcutItem;
     private ICommandItem[] _topLevelCommands = [];
+    private IFallbackCommandItem[] _fallbackCommands = [];
     private Storage? _storage;
 
     public WebSearchShortcutCommandsProvider()
@@ -48,6 +49,8 @@ public partial class WebSearchShortcutCommandsProvider : CommandProvider
 
         return _topLevelCommands;
     }
+
+    public override IFallbackCommandItem[] FallbackCommands() => _fallbackCommands;
 
     internal static string GetShortcutsJsonPath()
     {
@@ -102,6 +105,7 @@ public partial class WebSearchShortcutCommandsProvider : CommandProvider
     private void ReloadCommands()
     {
         List<ICommandItem> items = [_addShortcutItem];
+        List<IFallbackCommandItem> fallbackItem = [];
 
         if (_storage is null)
         {
@@ -111,9 +115,11 @@ public partial class WebSearchShortcutCommandsProvider : CommandProvider
         if (_storage is not null)
         {
             items.AddRange(_storage.Data.Select(CreateCommandItem));
+            fallbackItem.AddRange(_storage.Data.Select(shortcut => new FallbackSearchWebItem(shortcut)));
         }
 
         _topLevelCommands = [.. items];
+        _fallbackCommands = [.. fallbackItem];
     }
 
     private void LoadShortcutFromFile()


### PR DESCRIPTION
## Summary

This PR creates a corresponding fallback command for each web search shortcut, allowing users to type directly on the Command Palette home page and search with the selected engine.

## Motivation

* Shorter launch path: no need to enter a specific engine page first; just type on the home page to search.


## Key Changes

* Add `FallbackSearchWebItem`: wraps `SearchWebCommand` and adds the "Open home page" command to `MoreCommands`.
* Behavioral parity: matches the existing SearchWebCommand and provides the "Open home page" action with the same title/subtitle format.

* Implement `FallbackCommands()` in `WebSearchShortcutCommandsProvider` and create one `FallbackSearchWebItem` per shortcut at load time.