### PR TITLE
Upgrade packages and resolve Microsoft.CommandPalette.Extensions compatibility

### DIFF
--- a/CmdPalWebSearchShortcut/Directory.Packages.props
+++ b/CmdPalWebSearchShortcut/Directory.Packages.props
@@ -3,22 +3,22 @@
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
   </PropertyGroup>
   <ItemGroup>
-    <PackageVersion Include="Microsoft.CommandPalette.Extensions" Version="0.2.0" />
+    <PackageVersion Include="Microsoft.CommandPalette.Extensions" Version="0.9.260303001" />
     <PackageVersion Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="9.0.0-preview.24508.2" />
     <PackageVersion Include="Microsoft.Extensions.Logging" Version="10.0.5" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.5" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="10.0.5" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Debug" Version="10.0.5" />
-    <PackageVersion Include="Microsoft.Web.WebView2" Version="1.0.2903.40" />
+    <PackageVersion Include="Microsoft.Web.WebView2" Version="1.0.3856.49" />
     <PackageVersion Include="Microsoft.Windows.CsWin32" Version="0.2.46-beta" />
     <PackageVersion Include="Microsoft.Windows.CsWinRT" Version="2.2.0" />
     <PackageVersion Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.22621.2428" />
-    <PackageVersion Include="Microsoft.WindowsAppSDK" Version="1.7.250513003" />
-    <PackageVersion Include="Shmuelie.WinRTServer" Version="2.1.1" />
+    <PackageVersion Include="Microsoft.WindowsAppSDK" Version="1.8.260317003" />
+    <PackageVersion Include="Shmuelie.WinRTServer" Version="2.2.1" />
     <PackageVersion Include="StyleCop.Analyzers" Version="1.2.0-beta.556" />
-    <PackageVersion Include="System.Text.Json" Version="9.0.5" />
-    <PackageVersion Include="MSTest.TestFramework" Version="3.1.1" />
-    <PackageVersion Include="MSTest.TestAdapter" Version="3.1.1" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageVersion Include="System.Text.Json" Version="10.0.5" />
+    <PackageVersion Include="MSTest.TestFramework" Version="4.1.0" />
+    <PackageVersion Include="MSTest.TestAdapter" Version="4.1.0" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
   </ItemGroup>
 </Project>

--- a/CmdPalWebSearchShortcut/WebSearchShortcut/Pages/FallbackSearchWebItem.cs
+++ b/CmdPalWebSearchShortcut/WebSearchShortcut/Pages/FallbackSearchWebItem.cs
@@ -12,7 +12,7 @@ internal sealed partial class FallbackSearchWebItem : FallbackCommandItem
     private readonly WebSearchShortcutDataEntry _shortcut;
 
     public FallbackSearchWebItem(WebSearchShortcutDataEntry shortcut)
-        : base(new SearchWebCommand(shortcut, string.Empty) { Id = $"{shortcut.Id}.fallback" }, shortcut.Name)
+        : base(new SearchWebCommand(shortcut, string.Empty) { Id = $"{shortcut.Id}.fallback" }, shortcut.Name, $"{shortcut.Id}.fallback")
     {
         _shortcut = shortcut;
 

--- a/CmdPalWebSearchShortcut/WebSearchShortcut/Pages/FallbackSearchWebItem.cs
+++ b/CmdPalWebSearchShortcut/WebSearchShortcut/Pages/FallbackSearchWebItem.cs
@@ -12,7 +12,13 @@ internal sealed partial class FallbackSearchWebItem : FallbackCommandItem
     private readonly WebSearchShortcutDataEntry _shortcut;
 
     public FallbackSearchWebItem(WebSearchShortcutDataEntry shortcut)
-        : base(new SearchWebCommand(shortcut, string.Empty) { Id = $"{shortcut.Id}.fallback" }, shortcut.Name, $"{shortcut.Id}.fallback")
+        : base(
+            id: $"{shortcut.Id}.fallback",
+            displayTitle: shortcut.Name,
+            command: new SearchWebCommand(shortcut, string.Empty) {
+                Id = $"{shortcut.Id}.fallback"
+            }
+        )
     {
         _shortcut = shortcut;
 


### PR DESCRIPTION
This PR updates all packages to their latest versions. It includes necessary code changes to accommodate a breaking API update in the **Microsoft.CommandPalette.Extensions.Toolkit** package.

As with #81, the new `id` in `FallbackCommandItem` still has no effect. These changes are only made to support the latest package requirements.