### PR TITLE
feat: use literal replacement for whitespace separators

### DIFF
--- a/CmdPalWebSearchShortcut/WebSearchShortcut/WebSearchShortcutDataEntry.cs
+++ b/CmdPalWebSearchShortcut/WebSearchShortcut/WebSearchShortcutDataEntry.cs
@@ -30,15 +30,11 @@ internal sealed class WebSearchShortcutDataEntry
 
     static string UrlEncode(WebSearchShortcutDataEntry shortcut, string query)
     {
-        if (string.IsNullOrWhiteSpace(shortcut.ReplaceWhitespace) || shortcut.ReplaceWhitespace == " ")
-        {
-            return WebUtility.UrlEncode(query);
-        }
-        if (shortcut.ReplaceWhitespace == "%20")
-        {
-            return WebUtility.UrlEncode(query).Replace("+", "%20");
-        }
-        return WebUtility.UrlEncode(query.Replace(" ", shortcut.ReplaceWhitespace));
+        string encoded = WebUtility.UrlEncode(query);
+
+        return string.IsNullOrEmpty(shortcut.ReplaceWhitespace)
+            ? encoded
+            : encoded.Replace("+", shortcut.ReplaceWhitespace);
     }
 
     static public string GetSearchUrl(WebSearchShortcutDataEntry shortcut, string query)

--- a/README.md
+++ b/README.md
@@ -56,14 +56,15 @@ The URL template for performing the search. Use `%s` as a placeholder for the se
 
 With `ReplaceWhitespace`, you can specify which character(s) to replace a space with when performing a search. This is useful for some websites, such as Wikipedia, which don't use plus signs ("+") to separate words in the URL.
 
-| Value         | Result             |
-|---------------|--------------------|
-| `" "` or `""` | `Example+search`   |
-| `"-"`         | `Example-search`   |
-| `"_"`         | `Example_search`   |
-| `"+"`         | `Example%2Bsearch` |
+| Value          | Result             |
+|----------------|--------------------|
+| `""` (Default) | `Example+search`   |
+| `"+"`          | `Example+search`   |
+| `"%20"`        | `Example%20search` |
+| `"-"`          | `Example-search`   |
+| `"_"`          | `Example_search`   |
 
-> **Note**: As the string is converted to a URL, any spaces in the string (or `ReplaceWhitespace`) will be replaced with plus signs. Any other characters that are not allowed in a URL will be encoded with [percent-encoding](https://en.wikipedia.org/wiki/Percent-encoding).
+> **Note**: The character defined in `ReplaceWhitespace` will be used **literally** as the separator without further encoding. While some modern browsers may automatically encode invalid characters, users are responsible for ensuring their chosen character is valid and compatible with the target URL template. For more information on valid URL characters, please refer to [percent-encoding](https://en.wikipedia.org/wiki/Percent-encoding).
 
 ### `SuggestionProvider`
 


### PR DESCRIPTION
This PR improves the `ReplaceWhitespace` logic based on the feedback in #84.

Previously, using `+` as a separator would result in `%2B` due to double-encoding. This change allows the separator defined in settings to be used literally in the final URL, providing better control and compatibility for users.

Expected Behavior:
| Value          | Result             |
|----------------|--------------------|
| `""` (Default) | `Example+search`   |
| `"+"`          | `Example+search`   |
| `"%20"`        | `Example%20search` |
| `"-"`          | `Example-search`   |
| `"_"`          | `Example_search`   |

> Note: I didn't explicitly mention using a literal space (`" "`) because having an "invisible" value in the UI can be confusing and is generally not recommended.