### PR TITLE
fix: ensure main command displays icon in context menu

### DIFF
--- a/CmdPalWebSearchShortcut/WebSearchShortcut/Pages/FallbackSearchWebItem.cs
+++ b/CmdPalWebSearchShortcut/WebSearchShortcut/Pages/FallbackSearchWebItem.cs
@@ -16,15 +16,15 @@ internal sealed partial class FallbackSearchWebItem : FallbackCommandItem
             id: $"{shortcut.Id}.fallback",
             displayTitle: shortcut.Name,
             command: new SearchWebCommand(shortcut, string.Empty) {
-                Id = $"{shortcut.Id}.fallback"
+                Id = $"{shortcut.Id}.fallback",
+                Name = string.Empty,
+                Icon = Icons.Search
             }
         )
     {
         _shortcut = shortcut;
 
         _searchWebCommand = (SearchWebCommand) Command!;
-        _searchWebCommand.Name = string.Empty;
-        _searchWebCommand.Icon = Icons.Search;
 
         Title = string.Empty;
         Subtitle = string.Empty;

--- a/CmdPalWebSearchShortcut/WebSearchShortcut/Pages/FallbackSearchWebItem.cs
+++ b/CmdPalWebSearchShortcut/WebSearchShortcut/Pages/FallbackSearchWebItem.cs
@@ -24,6 +24,7 @@ internal sealed partial class FallbackSearchWebItem : FallbackCommandItem
 
         _searchWebCommand = (SearchWebCommand) Command!;
         _searchWebCommand.Name = string.Empty;
+        _searchWebCommand.Icon = Icons.Search;
 
         Title = string.Empty;
         Subtitle = string.Empty;

--- a/CmdPalWebSearchShortcut/WebSearchShortcut/Pages/SearchWebPage.cs
+++ b/CmdPalWebSearchShortcut/WebSearchShortcut/Pages/SearchWebPage.cs
@@ -38,7 +38,8 @@ internal sealed partial class SearchWebPage : DynamicListPage
 
         var openHomepagecommand = new OpenHomePageCommand(shortcut)
         {
-            Name = StringFormatter.Format(Resources.OpenHomepageItem_NameTemplate, new() { ["shortcut"] = shortcut.Name })
+            Name = StringFormatter.Format(Resources.OpenHomepageItem_NameTemplate, new() { ["shortcut"] = shortcut.Name }),
+            Icon = Icons.Home
         };
         _openHomepageListItem = new ListItem(openHomepagecommand)
         {
@@ -171,6 +172,7 @@ internal sealed partial class SearchWebPage : DynamicListPage
                 new SearchWebCommand(_shortcut, searchText)
                 {
                     Name = StringFormatter.Format(Resources.SearchQueryItem_NameTemplate, new() { ["shortcut"] = _shortcut.Name, ["query"] = searchText }),
+                    Icon = Icons.Search
                 }
             )
             {
@@ -195,7 +197,8 @@ internal sealed partial class SearchWebPage : DynamicListPage
             .. suggestions.Select(suggestion => new ListItem(
                 new SearchWebCommand(_shortcut, suggestion.Title)
                 {
-                    Name = StringFormatter.Format(Resources.SearchQueryItem_NameTemplate, new() { ["shortcut"] = _shortcut.Name, ["query"] =  suggestion.Title })
+                    Name = StringFormatter.Format(Resources.SearchQueryItem_NameTemplate, new() { ["shortcut"] = _shortcut.Name, ["query"] =  suggestion.Title }),
+                    Icon = Icons.Search
                 }
             )
             {


### PR DESCRIPTION
Assign the icon to the underlying `SearchWebCommand` and `OpenHomePageCommand` to prevent them from appearing without an icon when the "More Commands" context menu is opened via right-click.